### PR TITLE
Adapt code to use new KNoT AMQP API

### DIFF
--- a/src/cloud.c
+++ b/src/cloud.c
@@ -46,6 +46,7 @@
 #define MQ_EXCHANGE_FOG_OUT "fogOut"
 #define MQ_EXCHANGE_FOG_IN "fogIn"
 #define MQ_EXCHANGE_DEVICE "device"
+#define MQ_EXCHANGE_DATA_SENT "data.sent"
 
 /* Headers */
 #define MQ_AUTHORIZATION_HEADER "Authorization"
@@ -61,7 +62,6 @@
 #define MQ_EVENT_SCHEMA_UPDATED "schema.updated"
 
  /* Northbound traffic (control, measurements) */
-#define MQ_CMD_DATA_PUBLISH "data.publish"
 #define MQ_CMD_DEVICE_REGISTER "device.register"
 #define MQ_CMD_DEVICE_UNREGISTER "device.unregister"
 #define MQ_CMD_DEVICE_AUTH "device.cmd.auth"
@@ -481,9 +481,17 @@ int cloud_publish_data(const char *id, uint8_t sensor_id, uint8_t value_type,
 
 	headers[0].value.value.bytes = amqp_cstring_bytes(user_auth_token);
 
-	result = mq_publish_direct_persistent_msg(queue_cloud,
-						  MQ_EXCHANGE_FOG_IN,
-						  MQ_CMD_DATA_PUBLISH,
+	/**
+	 * Exchange
+	 *	Type: Fanout
+	 *	Name: data.sent
+	 * Headers
+	 *	[0]: User Token
+	 * Expiration
+	 *	2000 ms
+	 */
+	result = mq_publish_fanout_persistent_msg(queue_cloud,
+						  MQ_EXCHANGE_DATA_SENT,
 						  headers, 1,
 						  MQ_MSG_EXPIRATION_TIME_MS,
 						  json_str);

--- a/src/cloud.c
+++ b/src/cloud.c
@@ -313,8 +313,19 @@ int cloud_unregister_device(const char *id)
 
 	headers[0].value.value.bytes = amqp_cstring_bytes(user_auth_token);
 
+	/**
+	 * Exchange
+	 *	Type: Direct
+	 *	Name: device
+	 * Routing Key
+	 *	Name: device.unregister
+	 * Headers
+	 *	[0]: User Token
+	 * Expiration
+	 *	2000 ms
+	 */
 	result = mq_publish_direct_persistent_msg(queue_cloud,
-						  MQ_EXCHANGE_FOG_IN,
+						  MQ_EXCHANGE_DEVICE,
 						  MQ_CMD_DEVICE_UNREGISTER,
 						  headers, 1,
 						  MQ_MSG_EXPIRATION_TIME_MS,

--- a/src/cloud.c
+++ b/src/cloud.c
@@ -45,6 +45,7 @@
 /* Exchanges */
 #define MQ_EXCHANGE_FOG_OUT "fogOut"
 #define MQ_EXCHANGE_FOG_IN "fogIn"
+#define MQ_EXCHANGE_DEVICE "device"
 
 /* Headers */
 #define MQ_AUTHORIZATION_HEADER "Authorization"
@@ -254,8 +255,19 @@ int cloud_register_device(const char *id, const char *name)
 
 	headers[0].value.value.bytes = amqp_cstring_bytes(user_auth_token);
 
+	/**
+	 * Exchange
+	 *	Type: Direct
+	 *	Name: device
+	 * Routing Key
+	 *	Name: device.register
+	 * Headers
+	 *	[0]: User Token
+	 * Expiration
+	 *	2000 ms
+	 */
 	result = mq_publish_direct_persistent_msg(queue_cloud,
-						  MQ_EXCHANGE_FOG_IN,
+						  MQ_EXCHANGE_DEVICE,
 						  MQ_CMD_DEVICE_REGISTER,
 						  headers, 1,
 						  MQ_MSG_EXPIRATION_TIME_MS,

--- a/src/cloud.c
+++ b/src/cloud.c
@@ -65,7 +65,7 @@
 #define MQ_CMD_DEVICE_REGISTER "device.register"
 #define MQ_CMD_DEVICE_UNREGISTER "device.unregister"
 #define MQ_CMD_DEVICE_AUTH "device.cmd.auth"
-#define MQ_CMD_SCHEMA_UPDATE "schema.update"
+#define MQ_CMD_SCHEMA_SENT "device.schema.sent"
 
 cloud_cb_t cloud_cb;
 char *user_auth_token;
@@ -418,9 +418,20 @@ int cloud_update_schema(const char *id, struct l_queue *schema_list)
 
 	headers[0].value.value.bytes = amqp_cstring_bytes(user_auth_token);
 
+	/**
+	 * Exchange
+	 *	Type: Direct
+	 *	Name: device
+	 * Routing Key
+	 *	Name: device.schema.sent
+	 * Headers
+	 *	[0]: User Token
+	 * Expiration
+	 *	2000 ms
+	 */
 	result = mq_publish_direct_persistent_msg(queue_cloud,
-						  MQ_EXCHANGE_FOG_IN,
-						  MQ_CMD_SCHEMA_UPDATE,
+						  MQ_EXCHANGE_DEVICE,
+						  MQ_CMD_SCHEMA_SENT,
 						  headers, 1,
 						  MQ_MSG_EXPIRATION_TIME_MS,
 						  json_str);

--- a/src/cloud.c
+++ b/src/cloud.c
@@ -501,11 +501,18 @@ int cloud_set_read_handler(cloud_cb_t read_handler, void *user_data)
 		}
 	}
 
-	err = mq_set_read_cb(queue_fog, on_cloud_receive_message, user_data);
+	err = mq_set_read_cb(on_cloud_receive_message, user_data);
 	if (err) {
 		l_error("Error on set up read callback");
 		return -1;
 	}
+
+	err = mq_consumer_queue(queue_fog);
+	if (err) {
+		l_error("Error on start a queue consumer");
+		return -1;
+	}
+
 	amqp_bytes_free(queue_fog);
 
 	return 0;

--- a/src/cloud.c
+++ b/src/cloud.c
@@ -553,7 +553,8 @@ int cloud_set_read_handler(cloud_cb_t read_handler, void *user_data)
 	}
 
 	for (i = 0; fog_events[i] != NULL; i++) {
-		err = mq_bind_queue(queue_fog, MQ_EXCHANGE_FOG_OUT, fog_events[i]);
+		err = mq_prepare_direct_queue(queue_fog, MQ_EXCHANGE_FOG_OUT,
+					      fog_events[i]);
 		if (err) {
 			l_error("Error on set up queue to consume");
 			amqp_bytes_free(queue_fog);

--- a/src/cloud.c
+++ b/src/cloud.c
@@ -254,12 +254,12 @@ int cloud_register_device(const char *id, const char *name)
 
 	headers[0].value.value.bytes = amqp_cstring_bytes(user_auth_token);
 
-	result = mq_publish_persistent_message(queue_cloud,
-					       MQ_EXCHANGE_FOG_IN,
-					       MQ_CMD_DEVICE_REGISTER,
-					       headers, 1,
-					       MQ_MSG_EXPIRATION_TIME_MS,
-					       json_str);
+	result = mq_publish_direct_persistent_msg(queue_cloud,
+						  MQ_EXCHANGE_FOG_IN,
+						  MQ_CMD_DEVICE_REGISTER,
+						  headers, 1,
+						  MQ_MSG_EXPIRATION_TIME_MS,
+						  json_str);
 	if (result < 0)
 		result = KNOT_ERR_CLOUD_FAILURE;
 
@@ -301,12 +301,12 @@ int cloud_unregister_device(const char *id)
 
 	headers[0].value.value.bytes = amqp_cstring_bytes(user_auth_token);
 
-	result = mq_publish_persistent_message(queue_cloud,
-					       MQ_EXCHANGE_FOG_IN,
-					       MQ_CMD_DEVICE_UNREGISTER,
-					       headers, 1,
-					       MQ_MSG_EXPIRATION_TIME_MS,
-					       json_str);
+	result = mq_publish_direct_persistent_msg(queue_cloud,
+						  MQ_EXCHANGE_FOG_IN,
+						  MQ_CMD_DEVICE_UNREGISTER,
+						  headers, 1,
+						  MQ_MSG_EXPIRATION_TIME_MS,
+						  json_str);
 	if (result < 0)
 		return KNOT_ERR_CLOUD_FAILURE;
 
@@ -349,12 +349,12 @@ int cloud_auth_device(const char *id, const char *token)
 
 	headers[0].value.value.bytes = amqp_cstring_bytes(user_auth_token);
 
-	result = mq_publish_persistent_message(queue_cloud,
-					       MQ_EXCHANGE_FOG_IN,
-					       MQ_CMD_DEVICE_AUTH,
-					       headers, 1,
-					       MQ_MSG_EXPIRATION_TIME_MS,
-					       json_str);
+	result = mq_publish_direct_persistent_msg(queue_cloud,
+						  MQ_EXCHANGE_FOG_IN,
+						  MQ_CMD_DEVICE_AUTH,
+						  headers, 1,
+						  MQ_MSG_EXPIRATION_TIME_MS,
+						  json_str);
 	if (result < 0)
 		result = KNOT_ERR_CLOUD_FAILURE;
 
@@ -395,12 +395,12 @@ int cloud_update_schema(const char *id, struct l_queue *schema_list)
 
 	headers[0].value.value.bytes = amqp_cstring_bytes(user_auth_token);
 
-	result = mq_publish_persistent_message(queue_cloud,
-					       MQ_EXCHANGE_FOG_IN,
-					       MQ_CMD_SCHEMA_UPDATE,
-					       headers, 1,
-					       MQ_MSG_EXPIRATION_TIME_MS,
-					       json_str);
+	result = mq_publish_direct_persistent_msg(queue_cloud,
+						  MQ_EXCHANGE_FOG_IN,
+						  MQ_CMD_SCHEMA_UPDATE,
+						  headers, 1,
+						  MQ_MSG_EXPIRATION_TIME_MS,
+						  json_str);
 	if (result < 0)
 		result = KNOT_ERR_CLOUD_FAILURE;
 
@@ -447,12 +447,12 @@ int cloud_publish_data(const char *id, uint8_t sensor_id, uint8_t value_type,
 
 	headers[0].value.value.bytes = amqp_cstring_bytes(user_auth_token);
 
-	result = mq_publish_persistent_message(queue_cloud,
-					       MQ_EXCHANGE_FOG_IN,
-					       MQ_CMD_DATA_PUBLISH,
-					       headers, 1,
-					       MQ_MSG_EXPIRATION_TIME_MS,
-					       json_str);
+	result = mq_publish_direct_persistent_msg(queue_cloud,
+						  MQ_EXCHANGE_FOG_IN,
+						  MQ_CMD_DATA_PUBLISH,
+						  headers, 1,
+						  MQ_MSG_EXPIRATION_TIME_MS,
+						  json_str);
 	if (result < 0)
 		result = KNOT_ERR_CLOUD_FAILURE;
 

--- a/src/cloud.c
+++ b/src/cloud.c
@@ -69,6 +69,7 @@
 
 cloud_cb_t cloud_cb;
 amqp_bytes_t queue_reply;
+amqp_bytes_t queue_fog;
 char *user_auth_token;
 char *cloud_events[MSG_TYPES_LENGTH];
 amqp_table_entry_t headers[1];
@@ -221,7 +222,6 @@ static bool on_cloud_receive_message(const char *exchange,
 }
 static int create_fog_queue(const char *id)
 {
-	amqp_bytes_t queue_fog;
 	char queue_fog_name[100];
 	int msg_type;
 	int err;
@@ -240,7 +240,6 @@ static int create_fog_queue(const char *id)
 					      cloud_events[msg_type]);
 		if (err) {
 			l_error("Error on set up queue to consume");
-			amqp_bytes_free(queue_fog);
 			return -1;
 		}
 	}
@@ -251,7 +250,6 @@ static int create_fog_queue(const char *id)
 		return -1;
 	}
 
-	amqp_bytes_free(queue_fog);
 	return 0;
 }
 
@@ -605,6 +603,9 @@ void cloud_stop(void)
 {
 	if (queue_reply.bytes)
 		amqp_bytes_free(queue_reply);
+
+	if (queue_fog.bytes)
+		amqp_bytes_free(queue_fog);
 
 	destroy_cloud_events();
 	mq_stop();

--- a/src/cloud.c
+++ b/src/cloud.c
@@ -274,6 +274,25 @@ static int create_reply_queue(const char *id)
 	return 0;
 }
 
+static void destroy_cloud_queues(void)
+{
+	if (queue_reply.bytes) {
+		if (mq_delete_queue(queue_reply))
+			l_error("Error when delete Reply Queue");
+
+		amqp_bytes_free(queue_reply);
+		queue_reply = amqp_empty_bytes;
+	}
+
+	if (queue_fog.bytes) {
+		if (mq_delete_queue(queue_fog))
+			l_error("Error when delete Fog Queue");
+
+		amqp_bytes_free(queue_fog);
+		queue_fog = amqp_empty_bytes;
+	}
+}
+
 static int set_cloud_events(const char *id)
 {
 	char binding_key_reply[100];
@@ -601,11 +620,7 @@ int cloud_start(char *url, char *user_token, cloud_connected_cb_t connected_cb,
 
 void cloud_stop(void)
 {
-	if (queue_reply.bytes)
-		amqp_bytes_free(queue_reply);
-
-	if (queue_fog.bytes)
-		amqp_bytes_free(queue_fog);
+	destroy_cloud_queues();
 
 	destroy_cloud_events();
 	mq_stop();

--- a/src/cloud.h
+++ b/src/cloud.h
@@ -40,7 +40,8 @@ typedef bool (*cloud_cb_t) (const struct cloud_msg *msg, void *user_data);
 typedef void (*cloud_connected_cb_t) (void *user_data);
 typedef void (*cloud_disconnected_cb_t) (void *user_data);
 
-int cloud_set_read_handler(cloud_cb_t read_handler, void *user_data);
+int cloud_set_read_handler(const char *id, cloud_cb_t read_handler,
+			   void *user_data);
 int cloud_start(char *url, char *user_token, cloud_connected_cb_t connected_cb,
 		cloud_disconnected_cb_t disconnected_cb, void *user_data);
 void cloud_stop(void);

--- a/src/cloud.h
+++ b/src/cloud.h
@@ -41,8 +41,8 @@ typedef bool (*cloud_cb_t) (const struct cloud_msg *msg, void *user_data);
 typedef void (*cloud_connected_cb_t) (void *user_data);
 typedef void (*cloud_disconnected_cb_t) (void *user_data);
 
-int cloud_set_read_handler(const char *id, cloud_cb_t read_handler,
-			   void *user_data);
+int cloud_read_start(const char *id, cloud_cb_t read_handler,
+		     void *user_data);
 int cloud_start(char *url, char *user_token, cloud_connected_cb_t connected_cb,
 		cloud_disconnected_cb_t disconnected_cb, void *user_data);
 void cloud_stop(void);

--- a/src/cloud.h
+++ b/src/cloud.h
@@ -28,7 +28,8 @@ struct cloud_msg {
 		REGISTER_MSG,
 		UNREGISTER_MSG,
 		AUTH_MSG,
-		SCHEMA_MSG
+		SCHEMA_MSG,
+		MSG_TYPES_LENGTH
 	} type;
 	union {
 		const char *token; // used when type is REGISTER

--- a/src/device.c
+++ b/src/device.c
@@ -725,12 +725,6 @@ static bool on_cloud_receive(const struct cloud_msg *msg, void *user_data)
 
 static void on_cloud_connected(void *user_data)
 {
-	int err;
-
-	err = cloud_read_start(thing.id, on_cloud_receive, NULL);
-	if (err < 0)
-		return;
-
 	l_info("Connected to Cloud %s", thing.rabbitmq_url);
 
 	conn_handler(CLOUD, true);
@@ -859,6 +853,11 @@ void device_msg_timeout_remove(void)
 {
 	l_timeout_remove(thing.msg_to);
 	thing.msg_to = NULL;
+}
+
+int device_start_read_cloud(void)
+{
+	return cloud_read_start(thing.id, on_cloud_receive, NULL);
 }
 
 int device_start_config(void)

--- a/src/device.c
+++ b/src/device.c
@@ -726,7 +726,7 @@ static void on_cloud_connected(void *user_data)
 {
 	int err;
 
-	err = cloud_set_read_handler(on_cloud_receive, NULL);
+	err = cloud_set_read_handler(thing.id, on_cloud_receive, NULL);
 	if (err < 0)
 		return;
 

--- a/src/device.c
+++ b/src/device.c
@@ -715,6 +715,7 @@ static bool on_cloud_receive(const struct cloud_msg *msg, void *user_data)
 		else
 			sm_input_event(EVT_SCH_OK, NULL);
 		break;
+	case MSG_TYPES_LENGTH:
 	default:
 		return true;
 	}

--- a/src/device.c
+++ b/src/device.c
@@ -727,7 +727,7 @@ static void on_cloud_connected(void *user_data)
 {
 	int err;
 
-	err = cloud_set_read_handler(thing.id, on_cloud_receive, NULL);
+	err = cloud_read_start(thing.id, on_cloud_receive, NULL);
 	if (err < 0)
 		return;
 

--- a/src/device.h
+++ b/src/device.h
@@ -27,6 +27,7 @@ struct device_settings {
 void device_msg_timeout_create(int seconds);
 void device_msg_timeout_modify(int seconds);
 void device_msg_timeout_remove(void);
+int device_start_read_cloud(void);
 int device_start_config(void);
 void device_stop_config(void);
 int device_read_data(int id);

--- a/src/mq.c
+++ b/src/mq.c
@@ -529,6 +529,29 @@ amqp_bytes_t mq_declare_new_queue(const char *name)
 }
 
 /**
+ * mq_delete_queue:
+ * @name: queue name
+ *
+ * Delete a queue in amqp connection.
+ *
+ * Returns: 0 if successful and -1 otherwise.
+ */
+int mq_delete_queue(amqp_bytes_t queue)
+{
+	if (!mq_ctx.conn)
+		return -1;
+
+	amqp_queue_delete(mq_ctx.conn, 1, queue, 0, 0);
+	if (amqp_get_rpc_reply(mq_ctx.conn).reply_type !=
+			       AMQP_RESPONSE_NORMAL) {
+		l_error("Error deleting queue name");
+		return -1;
+	}
+
+	return 0;
+}
+
+/**
  * mq_prepare_queue:
  * @queue: queue declared
  * @exchange: exchange to be declared

--- a/src/mq.h
+++ b/src/mq.h
@@ -45,6 +45,12 @@ int8_t mq_publish_direct_persistent_msg(amqp_bytes_t queue,
 					size_t num_headers,
 					uint64_t expiration_ms,
 					const char *body);
+int8_t mq_publish_fanout_persistent_msg(amqp_bytes_t queue,
+					const char *exchange,
+					amqp_table_entry_t *headers,
+					size_t num_headers,
+					uint64_t expiration_ms,
+					const char *body);
 int mq_set_read_cb(amqp_bytes_t queue, mq_read_cb_t read_cb, void *user_data);
 int mq_start(char *url, mq_connected_cb_t connected_cb,
 	     mq_disconnected_cb_t disconnected_cb, void *user_data);

--- a/src/mq.h
+++ b/src/mq.h
@@ -23,28 +23,25 @@ typedef bool (*mq_read_cb_t) (const char *exchange, const char *routing_key,
 typedef void (*mq_connected_cb_t) (void *user_data);
 typedef void (*mq_disconnected_cb_t) (void *user_data);
 
-int8_t mq_publish_direct_persistent_msg_rpc(amqp_bytes_t queue,
-					    const char *exchange,
-					    const char *routing_key,
-					    amqp_table_entry_t *headers,
-					    size_t num_headers,
-					    uint64_t expiration_ms,
-					    amqp_bytes_t reply_to,
-					    const char *correlation_id,
-					    const char *body);
-int8_t mq_publish_direct_persistent_msg(amqp_bytes_t queue,
-					const char *exchange,
-					const char *routing_key,
-					amqp_table_entry_t *headers,
-					size_t num_headers,
-					uint64_t expiration_ms,
-					const char *body);
-int8_t mq_publish_fanout_persistent_msg(amqp_bytes_t queue,
-					const char *exchange,
-					amqp_table_entry_t *headers,
-					size_t num_headers,
-					uint64_t expiration_ms,
-					const char *body);
+int8_t mq_publish_direct_message_rpc(const char *exchange,
+				     const char *routing_key,
+				     amqp_table_entry_t *headers,
+				     size_t num_headers,
+				     uint64_t expiration_ms,
+				     amqp_bytes_t reply_to,
+				     const char *correlation_id,
+				     const char *body);
+int8_t mq_publish_direct_message(const char *exchange,
+				 const char *routing_key,
+				 amqp_table_entry_t *headers,
+				 size_t num_headers,
+				 uint64_t expiration_ms,
+				 const char *body);
+int8_t mq_publish_fanout_message(const char *exchange,
+				 amqp_table_entry_t *headers,
+				 size_t num_headers,
+				 uint64_t expiration_ms,
+				 const char *body);
 
 amqp_bytes_t mq_declare_new_queue(const char *name);
 int mq_prepare_direct_queue(amqp_bytes_t queue, const char *exchange,

--- a/src/mq.h
+++ b/src/mq.h
@@ -49,8 +49,9 @@ int8_t mq_publish_fanout_persistent_msg(amqp_bytes_t queue,
 amqp_bytes_t mq_declare_new_queue(const char *name);
 int mq_bind_queue(amqp_bytes_t queue, const char *exchange,
 		  const char *routing_key);
+int mq_consumer_queue(amqp_bytes_t queue);
 
-int mq_set_read_cb(amqp_bytes_t queue, mq_read_cb_t read_cb, void *user_data);
+int mq_set_read_cb(mq_read_cb_t read_cb, void *user_data);
 
 int mq_start(char *url, mq_connected_cb_t connected_cb,
 	     mq_disconnected_cb_t disconnected_cb, void *user_data);

--- a/src/mq.h
+++ b/src/mq.h
@@ -29,12 +29,22 @@ int mq_bind_queue(amqp_bytes_t queue,
 				const char *exchange,
 				const char *routing_key);
 amqp_bytes_t mq_declare_new_queue(const char *name);
-int8_t mq_publish_persistent_message(amqp_bytes_t queue, const char *exchange,
-				const char *routing_keys,
-				amqp_table_entry_t *headers,
-				size_t num_headers,
-				uint64_t expiration,
-				const char *body);
+int8_t mq_publish_direct_persistent_msg_rpc(amqp_bytes_t queue,
+					    const char *exchange,
+					    const char *routing_key,
+					    amqp_table_entry_t *headers,
+					    size_t num_headers,
+					    uint64_t expiration_ms,
+					    amqp_bytes_t reply_to,
+					    const char *correlation_id,
+					    const char *body);
+int8_t mq_publish_direct_persistent_msg(amqp_bytes_t queue,
+					const char *exchange,
+					const char *routing_key,
+					amqp_table_entry_t *headers,
+					size_t num_headers,
+					uint64_t expiration_ms,
+					const char *body);
 int mq_set_read_cb(amqp_bytes_t queue, mq_read_cb_t read_cb, void *user_data);
 int mq_start(char *url, mq_connected_cb_t connected_cb,
 	     mq_disconnected_cb_t disconnected_cb, void *user_data);

--- a/src/mq.h
+++ b/src/mq.h
@@ -44,6 +44,7 @@ int8_t mq_publish_fanout_message(const char *exchange,
 				 const char *body);
 
 amqp_bytes_t mq_declare_new_queue(const char *name);
+int mq_delete_queue(amqp_bytes_t queue);
 int mq_prepare_direct_queue(amqp_bytes_t queue, const char *exchange,
 			    const char *routing_key);
 int mq_consumer_queue(amqp_bytes_t queue);

--- a/src/mq.h
+++ b/src/mq.h
@@ -47,8 +47,8 @@ int8_t mq_publish_fanout_persistent_msg(amqp_bytes_t queue,
 					const char *body);
 
 amqp_bytes_t mq_declare_new_queue(const char *name);
-int mq_bind_queue(amqp_bytes_t queue, const char *exchange,
-		  const char *routing_key);
+int mq_prepare_direct_queue(amqp_bytes_t queue, const char *exchange,
+			    const char *routing_key);
 int mq_consumer_queue(amqp_bytes_t queue);
 
 int mq_set_read_cb(mq_read_cb_t read_cb, void *user_data);

--- a/src/mq.h
+++ b/src/mq.h
@@ -18,17 +18,11 @@
  *  Message Queue header file
  */
 
-typedef bool (*mq_read_cb_t) (const char *exchange,
-				const char *routing_key,
-				const char *body,
-				void *user_data);
+typedef bool (*mq_read_cb_t) (const char *exchange, const char *routing_key,
+			      const char *body, void *user_data);
 typedef void (*mq_connected_cb_t) (void *user_data);
 typedef void (*mq_disconnected_cb_t) (void *user_data);
 
-int mq_bind_queue(amqp_bytes_t queue,
-				const char *exchange,
-				const char *routing_key);
-amqp_bytes_t mq_declare_new_queue(const char *name);
 int8_t mq_publish_direct_persistent_msg_rpc(amqp_bytes_t queue,
 					    const char *exchange,
 					    const char *routing_key,
@@ -51,7 +45,13 @@ int8_t mq_publish_fanout_persistent_msg(amqp_bytes_t queue,
 					size_t num_headers,
 					uint64_t expiration_ms,
 					const char *body);
+
+amqp_bytes_t mq_declare_new_queue(const char *name);
+int mq_bind_queue(amqp_bytes_t queue, const char *exchange,
+		  const char *routing_key);
+
 int mq_set_read_cb(amqp_bytes_t queue, mq_read_cb_t read_cb, void *user_data);
+
 int mq_start(char *url, mq_connected_cb_t connected_cb,
 	     mq_disconnected_cb_t disconnected_cb, void *user_data);
 void mq_stop(void);

--- a/src/sm.c
+++ b/src/sm.c
@@ -137,6 +137,9 @@ enum STATES get_next_disconnected(enum EVENTS event, void *user_data)
 			next_state = ST_REGISTER;
 			device_generate_new_id();
 		}
+
+		if (device_start_read_cloud())
+			l_error("Fail to start cloud read");
 		break;
 	case EVT_NOT_READY:
 	case EVT_TIMEOUT:
@@ -243,6 +246,10 @@ enum STATES get_next_register(enum EVENTS event, void *user_data)
 		break;
 	case EVT_REG_NOT_OK:
 		device_generate_new_id();
+
+		if (device_start_read_cloud())
+			l_error("Fail to start cloud read");
+
 		next_state = ST_REGISTER;
 		break;
 	case EVT_TIMEOUT:
@@ -398,6 +405,10 @@ enum STATES get_next_unregister(enum EVENTS event, void *user_data)
 	switch(event) {
 	case EVT_REG_PERM:
 		device_generate_new_id();
+
+		if (device_start_read_cloud())
+			l_error("Fail to start cloud read");
+
 		next_state = ST_REGISTER;
 		break;
 	case EVT_NOT_READY:


### PR DESCRIPTION
This Pull Request adapt the code of VirtualThing to use the new KNoT AMQP API.

The new API AMQP can be visualized on [KNoT BabelTower](https://github.com/CESARBR/knot-babeltower) repository in the docs/events.md file.