### PR TITLE
Add an expiration time for messages

### DIFF
--- a/src/cloud.c
+++ b/src/cloud.c
@@ -353,7 +353,7 @@ int cloud_auth_device(const char *id, const char *token)
 					       MQ_EXCHANGE_FOG_IN,
 					       MQ_CMD_DEVICE_AUTH,
 					       headers, 1,
-					       0, // Set no expiration time
+					       MQ_MSG_EXPIRATION_TIME_MS,
 					       json_str);
 	if (result < 0)
 		result = KNOT_ERR_CLOUD_FAILURE;

--- a/src/device.c
+++ b/src/device.c
@@ -80,10 +80,15 @@ struct knot_thing {
 
 	int data_item_count;
 	struct knot_data_item *data_item;
+
+	struct l_timeout *msg_to;
 };
 
 static void knot_thing_destroy(struct knot_thing *thing)
 {
+	if (thing->msg_to)
+		l_timeout_remove(thing->msg_to);
+
 	l_free(thing->user_token);
 	l_free(thing->rabbitmq_url);
 	l_free(thing->modbus_slave.url);
@@ -800,6 +805,30 @@ static int create_data_item_polling(void)
 	}
 
 	return 0;
+}
+
+static void on_msg_timeout(struct l_timeout *timeout, void *user_data)
+{
+	sm_input_event(EVT_TIMEOUT, user_data);
+}
+
+void device_msg_timeout_create(int seconds)
+{
+	if (thing.msg_to)
+		return;
+
+	thing.msg_to = l_timeout_create(seconds, on_msg_timeout, NULL, NULL);
+}
+
+void device_msg_timeout_modify(int seconds)
+{
+	l_timeout_modify(thing.msg_to, seconds);
+}
+
+void device_msg_timeout_remove(void)
+{
+	l_timeout_remove(thing.msg_to);
+	thing.msg_to = NULL;
 }
 
 int device_start_config(void)

--- a/src/device.h
+++ b/src/device.h
@@ -24,6 +24,9 @@ struct device_settings {
 	char *rabbitmq_path;
 };
 
+void device_msg_timeout_create(int seconds);
+void device_msg_timeout_modify(int seconds);
+void device_msg_timeout_remove(void);
 int device_start_config(void);
 void device_stop_config(void);
 int device_read_data(int id);


### PR DESCRIPTION
Add an expiration time for messages sent to AMQP broker by doing the following changes:

- Resend auth, register, and schema messages after a timeout;
- Add an expiration time for AMQP auth message.