### PR TITLE
Refactor cloud disconnection handler

### DIFF
--- a/src/mq.c
+++ b/src/mq.c
@@ -187,8 +187,9 @@ static void on_disconnect(struct l_io *io, void *user_data)
 	mq_ctx.amqp_io = NULL;
 	mq_ctx.disconnected_cb(mq_ctx.connection_data);
 
-	l_timeout_modify_ms(mq_ctx.conn_retry_timeout,
-			    MQ_CONNECTION_RETRY_TIMEOUT_MS);
+	if (mq_ctx.conn_retry_timeout)
+		l_timeout_modify_ms(mq_ctx.conn_retry_timeout,
+				    MQ_CONNECTION_RETRY_TIMEOUT_MS);
 }
 
 static void attempt_connection(struct l_timeout *ltimeout, void *user_data)
@@ -652,6 +653,7 @@ void mq_stop(void)
 	int err;
 
 	l_timeout_remove(mq_ctx.conn_retry_timeout);
+	mq_ctx.conn_retry_timeout = NULL;
 
 	if (!mq_ctx.conn)
 		return;

--- a/src/mq.c
+++ b/src/mq.c
@@ -191,7 +191,7 @@ static void on_disconnect(struct l_io *io, void *user_data)
 			    MQ_CONNECTION_RETRY_TIMEOUT_MS);
 }
 
-static void start_connection(struct l_timeout *ltimeout, void *user_data)
+static void attempt_connection(struct l_timeout *ltimeout, void *user_data)
 {
 	const char *url = user_data;
 	amqp_socket_t *socket;
@@ -635,7 +635,7 @@ int mq_start(char *url, mq_connected_cb_t connected_cb,
 	mq_ctx.connection_data = user_data;
 
 	mq_ctx.conn_retry_timeout = l_timeout_create_ms(1, // start in oneshot
-							start_connection,
+							attempt_connection,
 							url, NULL);
 
 	return 0;

--- a/src/mq.c
+++ b/src/mq.c
@@ -261,6 +261,11 @@ static void attempt_connection(struct l_timeout *ltimeout, void *user_data)
 io_destroy:
 	l_io_destroy(mq_ctx.amqp_io);
 	mq_ctx.amqp_io = NULL;
+close_channel:
+	r = amqp_channel_close(mq_ctx.conn, 1, AMQP_REPLY_SUCCESS);
+	if (r.reply_type != AMQP_RESPONSE_NORMAL)
+		l_error("amqp_channel_close: %s",
+				mq_rpc_reply_string(r));
 close_conn:
 	r = amqp_connection_close(mq_ctx.conn, AMQP_REPLY_SUCCESS);
 	if (r.reply_type != AMQP_RESPONSE_NORMAL)


### PR DESCRIPTION
This PR applies a refactor on how the cloud management your disconnection. The motivation of this PR is because of the unnecessary creation of the ell io to verify the file descriptor and the wrong access of retry connection timeout.