### PR TITLE
Missing LIST_MSG case on switch Hotfix

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -194,6 +194,7 @@ static bool on_cloud_receive(const struct knot_cloud_msg *msg, void *user_data)
 		else
 			sm_input_event(EVT_SCH_OK, NULL);
 		break;
+	case LIST_MSG:
 	case MSG_TYPES_LENGTH:
 	default:
 		return true;


### PR DESCRIPTION
This patch is a Hot-fix to a bug generated by a switch inside
the function on_cloud_receive which doesn't handle the LIST_MSG case.