### PR TITLE
Set knot-cloud-sdk log priority

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -302,6 +302,11 @@ static int create_data_item_polling(void)
 	return rc;
 }
 
+void device_set_log_priority(int priority)
+{
+	knot_cloud_set_log_priority(priority);
+}
+
 char *device_get_id(void)
 {
 	return thing.id;

--- a/src/device.h
+++ b/src/device.h
@@ -27,6 +27,7 @@ struct device_settings {
 	char *cloud_path;
 };
 
+void device_set_log_priority(int priority);
 void device_set_thing_name(struct knot_thing *thing, const char *name);
 void device_set_thing_user_token(struct knot_thing *thing, char *token);
 void device_set_thing_modbus_slave(struct knot_thing *thing, int slave_id,

--- a/src/main.c
+++ b/src/main.c
@@ -96,10 +96,12 @@ static void log_stderr_handler(int priority, const char *file, const char *line,
 	vfprintf(stderr, format, ap);
 }
 
-static void log_ell_enable(int priority)
+static void log_enable(int priority)
 {
 	l_log_set_handler(log_stderr_handler);
 	log_priority = priority;
+
+	device_set_log_priority(priority);
 
 	if (log_priority == L_LOG_DEBUG)
 		l_debug_enable("*");
@@ -125,7 +127,7 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-	log_ell_enable(settings->log_level);
+	log_enable(settings->log_level);
 
 	conf_files = l_new(struct device_settings, 1);
 	set_device_settings(conf_files, settings);


### PR DESCRIPTION
This patch sets the knot-cloud-sdk log priority.
Depends on: https://github.com/CESARBR/knot-cloud-sdk-c/pull/9