### PR TITLE
Add floating number acquisition to modbus

### DIFF
--- a/src/conf-parameters.h
+++ b/src/conf-parameters.h
@@ -49,3 +49,10 @@
 
 #define MODBUS_REG_ADDRESS		"ModbusRegisterAddress"
 #define MODBUS_BIT_OFFSET		"ModbusBitOffset"
+#define MODBUS_TYPE_ENDIANNESS		"ModbusTypeEndianness"
+
+// definition of endianness type
+#define MODBUS_ENDIANNESS_TYPE_BIG_ENDIAN		0x01
+#define MODBUS_ENDIANNESS_TYPE_MID_BIG_ENDIAN		0x02
+#define MODBUS_ENDIANNESS_TYPE_LITTLE_ENDIAN		0x03
+#define MODBUS_ENDIANNESS_TYPE_MID_LITTLE_ENDIAN	0x04

--- a/src/device.c
+++ b/src/device.c
@@ -55,6 +55,7 @@ struct modbus_slave {
 struct modbus_source {
 	int reg_addr;
 	int bit_offset;
+	int endianness_type_sensor;
 };
 
 struct knot_data_item {
@@ -269,8 +270,9 @@ static int on_modbus_poll_receive(int id)
 		return -EINVAL;
 
 	rc = iface_modbus_read_data(data_item->modbus_source.reg_addr,
-				    data_item->modbus_source.bit_offset,
-				    &data_item->current_val);
+		data_item->modbus_source.bit_offset,
+		&data_item->current_val,
+		data_item->modbus_source.endianness_type_sensor);
 	if (event_check_value(data_item->event,
 			      data_item->current_val,
 			      data_item->sent_val,
@@ -342,7 +344,7 @@ void device_set_thing_modbus_slave(struct knot_thing *thing, int slave_id,
 
 void device_set_new_data_item(struct knot_thing *thing, int sensor_id,
 			      knot_schema schema, knot_event event,
-			      int reg_addr, int bit_offset)
+			      int reg_addr, int bit_offset, int endianness_type)
 {
 	struct knot_data_item *data_item_aux;
 
@@ -352,6 +354,7 @@ void device_set_new_data_item(struct knot_thing *thing, int sensor_id,
 	data_item_aux->event = event;
 	data_item_aux->modbus_source.reg_addr = reg_addr;
 	data_item_aux->modbus_source.bit_offset = bit_offset;
+	data_item_aux->modbus_source.endianness_type_sensor = endianness_type;
 
 	l_hashmap_insert(thing->data_items,
 			 L_INT_TO_PTR(data_item_aux->sensor_id),

--- a/src/device.h
+++ b/src/device.h
@@ -34,7 +34,8 @@ void device_set_thing_modbus_slave(struct knot_thing *thing, int slave_id,
 				   char *url);
 void device_set_new_data_item(struct knot_thing *thing, int sensor_id,
 			      knot_schema schema, knot_event event,
-			      int reg_addr, int bit_offset);
+			      int reg_addr, int bit_offset,
+			      int endianness_type);
 void device_update_config_data_item(struct knot_thing *thing,
 				    knot_msg_config *config);
 void *device_data_item_lookup(struct knot_thing *thing, int sensor_id);

--- a/src/iface-modbus.c
+++ b/src/iface-modbus.c
@@ -54,6 +54,7 @@ enum modbus_types_offset {
 };
 
 union modbus_types {
+	float val_float;
 	uint8_t val_bool;
 	uint8_t val_byte;
 	uint16_t val_u16;

--- a/src/iface-modbus.c
+++ b/src/iface-modbus.c
@@ -31,6 +31,7 @@
 #include <linux/serial.h>
 #include <asm-generic/ioctls.h>
 
+#include "conf-parameters.h"
 #include "iface-modbus.h"
 
 #define TCP_PREFIX "tcp://"
@@ -194,7 +195,59 @@ retry:
 	l_timeout_modify(to, RECONNECT_TIMEOUT);
 }
 
-int iface_modbus_read_data(int reg_addr, int bit_offset, knot_value_type *out)
+static void iface_modbus_config_endianness_type_recv_32_bits(uint32_t *src,
+				int endianness_type)
+{
+	switch (endianness_type) {
+	case MODBUS_ENDIANNESS_TYPE_BIG_ENDIAN:
+		*src = ((*src & 0xffff0000u) >> 16)|
+			((*src & 0x0000ffffu) << 16);
+		break;
+	case MODBUS_ENDIANNESS_TYPE_MID_BIG_ENDIAN:
+		*src = ((((*src) & 0xff000000u) >> 24)|
+			(((*src) & 0x00ff0000u) >> 8)|
+			(((*src) & 0x0000ff00u) << 8)|
+			(((*src) & 0x000000ffu) << 24));
+		break;
+	case MODBUS_ENDIANNESS_TYPE_LITTLE_ENDIAN:
+		*src = ((((*src) & 0xff000000u) >> 8)|
+			(((*src) & 0x00ff0000u) << 8)|
+			(((*src) & 0x0000ff00u) >> 8)|
+			(((*src) & 0x000000ffu) << 8));
+		break;
+	case MODBUS_ENDIANNESS_TYPE_MID_LITTLE_ENDIAN:
+		break;
+	default:
+		src = NULL;
+		break;
+	}
+}
+
+static void iface_modbus_config_endianness_type_recv_64_bits(uint64_t *src,
+				int endianness_type)
+{
+	if (endianness_type == MODBUS_ENDIANNESS_TYPE_MID_BIG_ENDIAN ||
+		endianness_type == MODBUS_ENDIANNESS_TYPE_LITTLE_ENDIAN){
+		*src = ((*src & 0xff00000000000000u) >> 8)|
+			((*src & 0x00ff000000000000u) << 8)|
+			((*src & 0x0000ff0000000000u) >> 8)|
+			((*src & 0x000000ff00000000u) << 8)|
+			((*src & 0x00000000ff000000u) >> 8)|
+			((*src & 0x0000000000ff0000u) << 8)|
+			((*src & 0x000000000000ff00u) >> 8)|
+			((*src & 0x00000000000000ffu) << 8);
+	}
+	if (endianness_type == MODBUS_ENDIANNESS_TYPE_MID_BIG_ENDIAN ||
+		endianness_type == MODBUS_ENDIANNESS_TYPE_BIG_ENDIAN){
+		*src = ((*src & 0xffff000000000000u) >> 48)|
+			((*src & 0x0000ffff00000000u) >> 16)|
+			((*src & 0x00000000ffff0000u) << 16)|
+			((*src & 0x000000000000ffffu) << 48);
+	}
+}
+
+int iface_modbus_read_data(int reg_addr, int bit_offset, knot_value_type *out,
+			   int endianness_type)
 {
 	int rc;
 	union modbus_types tmp;
@@ -224,10 +277,14 @@ int iface_modbus_read_data(int reg_addr, int bit_offset, knot_value_type *out)
 	case TYPE_U32:
 		rc = modbus_read_registers(modbus_ctx, reg_addr, 2,
 					   (uint16_t *) &tmp.val_u32);
+		iface_modbus_config_endianness_type_recv_32_bits(&tmp.val_u32,
+						endianness_type);
 		break;
 	case TYPE_U64:
 		rc = modbus_read_registers(modbus_ctx, reg_addr, 4,
 					   (uint16_t *) &tmp.val_u64);
+		iface_modbus_config_endianness_type_recv_64_bits(&tmp.val_u64,
+						endianness_type);
 		break;
 	default:
 		rc = -EINVAL;
@@ -275,3 +332,4 @@ void iface_modbus_stop(void)
 	modbus_close(modbus_ctx);
 	modbus_free(modbus_ctx);
 }
+

--- a/src/iface-modbus.h
+++ b/src/iface-modbus.h
@@ -20,7 +20,8 @@ extern struct modbus_driver rtu;
 typedef void (*iface_modbus_connected_cb_t) (void *user_data);
 typedef void (*iface_modbus_disconnected_cb_t) (void *user_data);
 
-int iface_modbus_read_data(int reg_addr, int bit_offset, knot_value_type *out);
+int iface_modbus_read_data(int reg_addr, int bit_offset, knot_value_type *out,
+			   int endianness_type);
 int iface_modbus_start(const char *url, int slave_id,
 		       iface_modbus_connected_cb_t connected_cb,
 		       iface_modbus_disconnected_cb_t disconnected_cb,

--- a/src/properties.c
+++ b/src/properties.c
@@ -124,11 +124,13 @@ static int valid_bit_offset(int bit_offset, int value_type)
 		/* KNoT Protocol doesn't have a matching value type */
 	case 32:
 		valid_value_type_mask = (1 << KNOT_VALUE_TYPE_INT) |
-					(1 << KNOT_VALUE_TYPE_UINT);
+					(1 << KNOT_VALUE_TYPE_UINT) |
+					(1 << KNOT_VALUE_TYPE_FLOAT);
 		break;
 	case 64:
 		valid_value_type_mask = (1 << KNOT_VALUE_TYPE_INT64) |
-					(1 << KNOT_VALUE_TYPE_UINT64);
+					(1 << KNOT_VALUE_TYPE_UINT64) |
+					(1 << KNOT_VALUE_TYPE_FLOAT);
 		break;
 	default:
 		return -EINVAL;


### PR DESCRIPTION
Add floating number acquisition to modbus by doing the following changes:
- Fix endiannes condition for 64 bits;
- Fix endiannes condition for 32 bits;
- Add endianness condition to device.conf;
- Add possibility to receive float with 32 bits.
