### PR TITLE
Add ethernet ip with driver flow

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,6 +17,7 @@ src_thingd_SOURCES = src/main.c \
 			src/device.c src/device.h \
 			src/storage.c src/storage.h \
 			src/iface-modbus.c src/iface-modbus.h \
+			src/iface-ethernet-ip.c src/iface-ethernet-ip.h \
 			src/settings.c src/settings.h \
 			src/event.c src/event.h \
 			src/poll.c src/poll.h \

--- a/src/conf-device.h
+++ b/src/conf-device.h
@@ -14,24 +14,22 @@
  *  Lesser General Public License for more details.
  */
 
-#define DRIVER_ETHERNET_IP		1
-#define DRIVER_MODBUS			0
+#define DRIVER_MAX_PROTOCOL_TYPE_LEN	25
+#define DRIVER_MAX_NAME_TYPE_LEN	25
+#define DRIVER_MAX_URL_LEN		50
 
-#define THING_ETHERNET_IP_MAX_TYPE_PLC_LEN	25
-#define THING_MAX_URL_LEN		50
+#define DRIVER_MAX_TYPE_TAG_LEN			30
+#define DRIVER_MAX_TYPE_PATH_LEN		5
+#define DRIVER_MAX_TYPE_STRING_CONNECT_LEN	512
 
-#define ETHERNET_IP_MAX_TYPE_TAG_LEN	30
-#define ETHERNET_IP_MAX_TYPE_PATH_LEN	5
-#define ETHERNET_IP_MAX_TYPE_STRING_CONNECT_LEN 512
+#define DRIVER_MIN_ID		0
+#define DRIVER_MAX_ID		255
 
-#define MODBUS_MIN_SLAVE_ID		0
-#define MODBUS_MAX_SLAVE_ID		255
-
-// definition of endianness type
 #define ENDIANNESS_TYPE_BIG_ENDIAN		0x01
 #define ENDIANNESS_TYPE_MID_BIG_ENDIAN		0x02
 #define ENDIANNESS_TYPE_LITTLE_ENDIAN		0x03
 #define ENDIANNESS_TYPE_MID_LITTLE_ENDIAN	0x04
+
 
 enum CONN_TYPE {
 	DRIVER = 0x0F,
@@ -44,22 +42,6 @@ struct device_settings {
 	char *cloud_path;
 };
 
-struct modbus_slave {
-	int id;
-};
-
-struct ethernet_ip_settings {
-	char plc_type[THING_ETHERNET_IP_MAX_TYPE_PLC_LEN];
-};
-
-struct ethernet_ip_data_settings {
-	int32_t tag;
-	char tag_name[ETHERNET_IP_MAX_TYPE_TAG_LEN];
-	char path[ETHERNET_IP_MAX_TYPE_PATH_LEN];
-	int element_size;
-	char string_tag_path[ETHERNET_IP_MAX_TYPE_STRING_CONNECT_LEN];
-};
-
 struct knot_data_item {
 	int sensor_id;
 	knot_schema schema;
@@ -68,8 +50,11 @@ struct knot_data_item {
 	knot_value_type sent_val;
 	int reg_addr;
 	int value_type_size;
-	int endianness_type_sensor;
-	struct ethernet_ip_data_settings ethernet_ip_data_settings;
+	int32_t tag;
+	char tag_name[DRIVER_MAX_TYPE_TAG_LEN];
+	char path[DRIVER_MAX_TYPE_PATH_LEN];
+	int element_size;
+	char string_tag_path[DRIVER_MAX_TYPE_STRING_CONNECT_LEN];
 };
 
 struct knot_thing {
@@ -78,13 +63,14 @@ struct knot_thing {
 	char name[KNOT_PROTOCOL_DEVICE_NAME_LEN];
 	char *user_token;
 
-	struct modbus_slave modbus_slave;
-	struct ethernet_ip_settings ethernet_ip_settings;
+	char protocol_type[DRIVER_MAX_PROTOCOL_TYPE_LEN];
+	int endianness_type;
+	char name_type[DRIVER_MAX_NAME_TYPE_LEN];
+	int driver_id;
 	char *rabbitmq_url;
 	struct device_settings conf_files;
-	char geral_url[THING_MAX_URL_LEN];
+	char geral_url[DRIVER_MAX_URL_LEN];
 	struct l_hashmap *data_items;
 
 	struct l_timeout *msg_to;
 };
-

--- a/src/conf-driver.h
+++ b/src/conf-driver.h
@@ -14,6 +14,9 @@
  *  Lesser General Public License for more details.
  */
 
+#define DRIVER_ETHERNET_IP		1
+#define DRIVER_MODBUS			0
+
 #define THING_ETHERNET_IP_MAX_TYPE_PLC_LEN	25
 #define THING_MAX_URL_LEN		50
 

--- a/src/conf-driver.h
+++ b/src/conf-driver.h
@@ -1,0 +1,88 @@
+/**
+ * This file is part of the KNOT Project
+ *
+ * Copyright (c) 2021, CESAR. All rights reserved.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ */
+
+#define THING_ETHERNET_IP_MAX_TYPE_PLC_LEN	25
+#define THING_MAX_URL_LEN		50
+
+#define ETHERNET_IP_MAX_TYPE_TAG_LEN	30
+#define ETHERNET_IP_MAX_TYPE_PATH_LEN	5
+#define ETHERNET_IP_MAX_TYPE_STRING_CONNECT_LEN 512
+
+#define MODBUS_MIN_SLAVE_ID		0
+#define MODBUS_MAX_SLAVE_ID		255
+
+// definition of endianness type
+#define ENDIANNESS_TYPE_BIG_ENDIAN		0x01
+#define ENDIANNESS_TYPE_MID_BIG_ENDIAN		0x02
+#define ENDIANNESS_TYPE_LITTLE_ENDIAN		0x03
+#define ENDIANNESS_TYPE_MID_LITTLE_ENDIAN	0x04
+
+enum CONN_TYPE {
+	MODBUS = 0x00F,
+	ETHERNET_IP = 0x0F0,
+	CLOUD = 0xF00
+};
+
+struct device_settings {
+	char *credentials_path;
+	char *device_path;
+	char *cloud_path;
+};
+
+struct modbus_slave {
+	int id;
+};
+
+struct ethernet_ip_settings {
+	char plc_type[THING_ETHERNET_IP_MAX_TYPE_PLC_LEN];
+};
+
+struct ethernet_ip_data_settings {
+	int32_t tag;
+	char tag_name[ETHERNET_IP_MAX_TYPE_TAG_LEN];
+	char path[ETHERNET_IP_MAX_TYPE_PATH_LEN];
+	int element_size;
+	char string_tag_path[ETHERNET_IP_MAX_TYPE_STRING_CONNECT_LEN];
+};
+
+struct knot_data_item {
+	int sensor_id;
+	knot_schema schema;
+	knot_event event;
+	knot_value_type current_val;
+	knot_value_type sent_val;
+	int reg_addr;
+	int value_type_size;
+	int endianness_type_sensor;
+	struct ethernet_ip_data_settings ethernet_ip_data_settings;
+};
+
+struct knot_thing {
+	char token[KNOT_PROTOCOL_TOKEN_LEN + 1];
+	char id[KNOT_PROTOCOL_UUID_LEN + 1];
+	char name[KNOT_PROTOCOL_DEVICE_NAME_LEN];
+	char *user_token;
+
+	struct modbus_slave modbus_slave;
+	struct ethernet_ip_settings ethernet_ip_settings;
+	char *rabbitmq_url;
+	struct device_settings conf_files;
+	char geral_url[THING_MAX_URL_LEN];
+	struct l_hashmap *data_items;
+
+	struct l_timeout *msg_to;
+};
+

--- a/src/conf-driver.h
+++ b/src/conf-driver.h
@@ -34,9 +34,8 @@
 #define ENDIANNESS_TYPE_MID_LITTLE_ENDIAN	0x04
 
 enum CONN_TYPE {
-	MODBUS = 0x00F,
-	ETHERNET_IP = 0x0F0,
-	CLOUD = 0xF00
+	DRIVER = 0x0F,
+	CLOUD = 0xF0
 };
 
 struct device_settings {

--- a/src/conf-parameters.h
+++ b/src/conf-parameters.h
@@ -55,6 +55,3 @@
 #define DATA_REG_ADDRESS		"RegisterAddress"
 #define DATA_TYPE_ENDIANNESS		"TypeEndianness"
 #define DATA_VALUE_TYPE_SIZE		"ValueTypeSize"
-
-#define DRIVER_ETHERNET_IP		1
-#define DRIVER_MODBUS			0

--- a/src/conf-parameters.h
+++ b/src/conf-parameters.h
@@ -30,10 +30,15 @@
 #define THING_GROUP			"KNoTThing"
 #define THING_NAME			"Name"
 #define THING_USER_TOKEN		"UserToken"
+#define THING_URL			"ThingURL"
 #define THING_MODBUS_SLAVE_ID		"ModbusSlaveId"
-#define THING_MODBUS_URL		"ModbusURL"
-#define MODBUS_MIN_SLAVE_ID		0
-#define MODBUS_MAX_SLAVE_ID		255
+
+#define THING_ETHERNET_IP_PLC_TYPE		"EthernetIpPLCType"
+
+#define ETHERNET_IP_TAG_NAME		"EthernetTagName"
+#define ETHERNET_IP_ELEMENT_SIZE	"EthernetIpElementSize"
+#define ETHERNET_IP_PATH		"EthernetIpPath"
+
 
 #define SCHEMA_SENSOR_ID		"SchemaSensorId"
 #define SCHEMA_SENSOR_NAME		"SchemaSensorName"
@@ -47,12 +52,9 @@
 #define EVENT_CHANGE			"EventChange"
 #define EVENT_CHANGE_TRUE		1
 
-#define MODBUS_REG_ADDRESS		"ModbusRegisterAddress"
-#define MODBUS_BIT_OFFSET		"ModbusBitOffset"
-#define MODBUS_TYPE_ENDIANNESS		"ModbusTypeEndianness"
+#define DATA_REG_ADDRESS		"RegisterAddress"
+#define DATA_TYPE_ENDIANNESS		"TypeEndianness"
+#define DATA_VALUE_TYPE_SIZE		"ValueTypeSize"
 
-// definition of endianness type
-#define MODBUS_ENDIANNESS_TYPE_BIG_ENDIAN		0x01
-#define MODBUS_ENDIANNESS_TYPE_MID_BIG_ENDIAN		0x02
-#define MODBUS_ENDIANNESS_TYPE_LITTLE_ENDIAN		0x03
-#define MODBUS_ENDIANNESS_TYPE_MID_LITTLE_ENDIAN	0x04
+#define DRIVER_ETHERNET_IP		1
+#define DRIVER_MODBUS			0

--- a/src/conf-parameters.h
+++ b/src/conf-parameters.h
@@ -25,20 +25,22 @@
 #define CLOUD_GROUP			"Cloud"
 #define RABBIT_URL			"Url"
 
-#define DATA_ITEM_GROUP			"DataItem_"
-
 #define THING_GROUP			"KNoTThing"
 #define THING_NAME			"Name"
 #define THING_USER_TOKEN		"UserToken"
-#define THING_URL			"ThingURL"
-#define THING_MODBUS_SLAVE_ID		"ModbusSlaveId"
 
-#define THING_ETHERNET_IP_PLC_TYPE		"EthernetIpPLCType"
+#define DRIVER_URL			"DriverURL"
+#define DRIVER_PROTOCOL_TYPE		"DeviceProtocolType"
+#define DRIVER_ID			"DeviceId"
+#define DRIVER_NAME_TYPE		"DeviceNameType"
 
-#define ETHERNET_IP_TAG_NAME		"EthernetTagName"
-#define ETHERNET_IP_ELEMENT_SIZE	"EthernetIpElementSize"
-#define ETHERNET_IP_PATH		"EthernetIpPath"
-
+#define DATA_ITEM_GROUP			"DataItem_"
+#define DATA_IP_TAG_NAME		"DataTagName"
+#define DATA_IP_ELEMENT_SIZE		"DataIpElementSize"
+#define DATA_IP_PATH			"DataIpPath"
+#define DATA_REG_ADDRESS		"RegisterAddress"
+#define DATA_TYPE_ENDIANNESS		"TypeEndianness"
+#define DATA_VALUE_TYPE_SIZE		"ValueTypeSize"
 
 #define SCHEMA_SENSOR_ID		"SchemaSensorId"
 #define SCHEMA_SENSOR_NAME		"SchemaSensorName"
@@ -52,6 +54,3 @@
 #define EVENT_CHANGE			"EventChange"
 #define EVENT_CHANGE_TRUE		1
 
-#define DATA_REG_ADDRESS		"RegisterAddress"
-#define DATA_TYPE_ENDIANNESS		"TypeEndianness"
-#define DATA_VALUE_TYPE_SIZE		"ValueTypeSize"

--- a/src/device.c
+++ b/src/device.c
@@ -207,22 +207,18 @@ static void on_cloud_connected(void *user_data)
 
 static void on_driver_disconnected(void *user_data)
 {
-	enum CONN_TYPE *type_aux = user_data;
-
 	l_info("Disconnected");
 
 	poll_stop();
-	conn_handler(*type_aux, false);
+	conn_handler(DRIVER, false);
 }
 
 static void on_driver_connected(void *user_data)
 {
-	enum CONN_TYPE *type_aux = user_data;
-
 	l_info("Connected to %s", thing.geral_url);
 
 	poll_start();
-	conn_handler(*type_aux, true);
+	conn_handler(DRIVER, true);
 }
 
 static int on_poll_receive(int id)

--- a/src/device.c
+++ b/src/device.c
@@ -234,15 +234,19 @@ static int on_poll_receive(int id)
 	data_item = l_hashmap_lookup(thing.data_items, L_INT_TO_PTR(id));
 	if (!data_item)
 		return -EINVAL;
-#ifdef DRIVER_MODBUS
+#if DRIVER_MODBUS
 	rc = iface_modbus_read_data(data_item->reg_addr,
 				    data_item->value_type_size,
 				    &data_item->current_val,
 				    data_item->endianness_type_sensor);
-#endif /* DRIVER_MODBUS */
-
-#ifdef DRIVER_ETHERNET_IP
-#endif /* DRIVER_ETHERNET_IP */
+#elif DRIVER_ETHERNET_IP
+	rc = iface_ethernet_ip_read_data(
+				    data_item->ethernet_ip_data_settings.tag,
+				    data_item->reg_addr,
+				    data_item->schema.value_type,
+				    data_item->value_type_size,
+				    &data_item->current_val);
+#endif
 
 	if (event_check_value(data_item->event,
 			      data_item->current_val,

--- a/src/device.c
+++ b/src/device.c
@@ -584,7 +584,13 @@ int device_start(struct device_settings *conf_files)
 	if (err < 0) {
 		l_error("Failed to initialize Cloud");
 		poll_destroy();
+
+#if DRIVER_MODBUS
 		iface_modbus_stop();
+#elif DRIVER_ETHERNET_IP
+		iface_ethernet_ip_stop();
+#endif
+
 		knot_thing_destroy(&thing);
 		return err;
 	}
@@ -605,7 +611,10 @@ void device_destroy(void)
 
 	poll_destroy();
 	knot_cloud_stop();
+#if DRIVER_MODBUS
 	iface_modbus_stop();
-
+#elif DRIVER_ETHERNET_IP
+	iface_ethernet_ip_stop();
+#endif
 	knot_thing_destroy(&thing);
 }

--- a/src/device.h
+++ b/src/device.h
@@ -20,12 +20,7 @@
 
 struct knot_data_item;
 struct knot_thing;
-
-struct device_settings {
-	char *credentials_path;
-	char *device_path;
-	char *cloud_path;
-};
+struct device_settings;
 
 void device_set_log_priority(int priority);
 void device_set_thing_name(struct knot_thing *thing, const char *name);

--- a/src/device.h
+++ b/src/device.h
@@ -18,21 +18,24 @@
  *  Device header file
  */
 
-struct knot_data_item;
 struct knot_thing;
+struct knot_data_item;
 struct device_settings;
 
 void device_set_log_priority(int priority);
 void device_set_thing_name(struct knot_thing *thing, const char *name);
-void device_set_thing_url(struct knot_thing *thing, const char *url);
+void device_set_driver_url(struct knot_thing *thing, const char *url);
 void device_set_thing_user_token(struct knot_thing *thing, char *token);
-void device_set_thing_modbus_slave(struct knot_thing *thing, int slave_id);
-void device_set_thing_ethernet_ip_slave(struct knot_thing *thing,
-					const char *type_plc);
+void device_set_protocol_type(struct knot_thing *thing,
+			      const char *protocol_type);
+void device_set_endianness_type(struct knot_thing *thing,
+				int endianness_type);
+void device_set_driver_id(struct knot_thing *thing, int slave_id);
+void device_set_driver_name_type(struct knot_thing *thing,
+				const char *name_type);
 void device_set_new_data_item(struct knot_thing *thing, int sensor_id,
 			      knot_schema schema, knot_event event,
-			      int reg_addr, int value_type_size,
-			      int endianness_type, void *driver_buffer);
+			      struct knot_data_item data_aux);
 void device_update_config_data_item(struct knot_thing *thing,
 				    knot_msg_config *config);
 void *device_data_item_lookup(struct knot_thing *thing, int sensor_id);

--- a/src/device.h
+++ b/src/device.h
@@ -29,13 +29,15 @@ struct device_settings {
 
 void device_set_log_priority(int priority);
 void device_set_thing_name(struct knot_thing *thing, const char *name);
+void device_set_thing_url(struct knot_thing *thing, const char *url);
 void device_set_thing_user_token(struct knot_thing *thing, char *token);
-void device_set_thing_modbus_slave(struct knot_thing *thing, int slave_id,
-				   char *url);
+void device_set_thing_modbus_slave(struct knot_thing *thing, int slave_id);
+void device_set_thing_ethernet_ip_slave(struct knot_thing *thing,
+					const char *type_plc);
 void device_set_new_data_item(struct knot_thing *thing, int sensor_id,
 			      knot_schema schema, knot_event event,
-			      int reg_addr, int bit_offset,
-			      int endianness_type);
+			      int reg_addr, int value_type_size,
+			      int endianness_type, void *driver_buffer);
 void device_update_config_data_item(struct knot_thing *thing,
 				    knot_msg_config *config);
 void *device_data_item_lookup(struct knot_thing *thing, int sensor_id);

--- a/src/driver.c
+++ b/src/driver.c
@@ -1,0 +1,78 @@
+/**
+ * This file is part of the KNOT Project
+ *
+ * Copyright (c) 2021, CESAR. All rights reserved.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ */
+
+#include <stdio.h>
+#include <ell/ell.h>
+#include <knot/knot_protocol.h>
+
+#include "driver.h"
+#include "conf-device.h"
+#include "iface-modbus.h"
+#include "iface-ethernet-ip.h"
+
+static driver_protocols_type map_settings_protocols(char *protocol)
+{
+	if (!strcmp(protocol, "MODBUS"))
+		return MODBUS;
+	else if (!strcmp(protocol, "ETHERNET/IP"))
+		return ETHERNET_IP;
+	return -1;
+}
+
+static struct driver_ops *create_ethernet_ip_driver(void)
+{
+	struct driver_ops *ethernet_ip_ops = l_new(struct driver_ops, 1);
+
+	ethernet_ip_ops->type = ETHERNET_IP;
+	ethernet_ip_ops->start = iface_ethernet_ip_start;
+	ethernet_ip_ops->stop = iface_ethernet_ip_stop;
+	ethernet_ip_ops->read = iface_ethernet_ip_read_data;
+
+	return ethernet_ip_ops;
+}
+
+static struct driver_ops *create_modbus_driver(void)
+{
+	struct driver_ops *modbus_ops = l_new(struct driver_ops, 1);
+
+	modbus_ops->type = MODBUS;
+	modbus_ops->start = iface_modbus_start;
+	modbus_ops->stop = iface_modbus_stop;
+	modbus_ops->read = iface_modbus_read_data;
+
+	return modbus_ops;
+}
+
+struct driver_ops *create_driver(char *protocol)
+{
+	driver_protocols_type protocol_aux;
+
+	protocol_aux = map_settings_protocols(protocol);
+
+	switch (protocol_aux) {
+	case MODBUS:
+		return create_modbus_driver();
+	case ETHERNET_IP:
+		return create_ethernet_ip_driver();
+	default:
+		return NULL;
+	}
+}
+
+void destroy_driver(struct driver_ops *driver)
+{
+	l_free(driver);
+}

--- a/src/driver.h
+++ b/src/driver.h
@@ -1,0 +1,51 @@
+/**
+ * This file is part of the KNOT Project
+ *
+ * Copyright (c) 2021, CESAR. All rights reserved.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ */
+
+#define DRIVER_MAX_PROTOCOL_TYPE_LEN	25
+#define DRIVER_MAX_NAME_TYPE_LEN	25
+#define DRIVER_MAX_URL_LEN		50
+
+#define DRIVER_MAX_TYPE_TAG_LEN			30
+#define DRIVER_MAX_TYPE_PATH_LEN		5
+#define DRIVER_MAX_TYPE_STRING_CONNECT_LEN	512
+
+#define DRIVER_MIN_ID		0
+#define DRIVER_MAX_ID		255
+
+struct knot_thing;
+struct knot_data_item;
+
+typedef void (*driver_connected_cb_t) (void *user_data);
+typedef void (*driver_disconnected_cb_t) (void *user_data);
+
+typedef enum DRIVER_PROTOCOLS {
+	MODBUS,
+	ETHERNET_IP
+} driver_protocols_type;
+
+struct driver_ops {
+	driver_protocols_type type;
+
+	int (*read)(struct knot_data_item *data_item);
+	int (*start)(struct knot_thing thing_props,
+		     driver_connected_cb_t connected_cb,
+		     driver_disconnected_cb_t disconnected_cb,
+		     void *user_data);
+	void (*stop)(void);
+};
+
+struct driver_ops *create_driver(char *type);
+void destroy_driver(struct driver_ops *driver);

--- a/src/iface-ethernet-ip.c
+++ b/src/iface-ethernet-ip.c
@@ -195,7 +195,6 @@ int iface_ethernet_ip_read_data(int tag, int reg_addr, uint8_t value_type,
 {
 	int rc;
 	union ethernet_ip_types tmp;
-	enum CONN_TYPE type_connect_aux = ETHERNET_IP;
 
 	memset(&tmp, 0, sizeof(tmp));
 
@@ -241,7 +240,7 @@ int iface_ethernet_ip_read_data(int tag, int reg_addr, uint8_t value_type,
 	} else {
 		l_error("Unable to read the data! Got error code %d: %s\n",
 			rc, plc_tag_decode_error(rc));
-		on_disconnected((void *) &type_connect_aux);
+		on_disconnected(NULL);
 	}
 
 	return rc;
@@ -252,7 +251,6 @@ int iface_ethernet_ip_start(struct knot_thing thing,
 		       iface_ethernet_ip_disconnected_cb_t disconnected_cb,
 		       void *user_data)
 {
-	enum CONN_TYPE type_connect = ETHERNET_IP;
 	thing_ethernet_ip = thing;
 
 	if (plc_tag_check_lib_version(REQUIRED_VERSION_MAJOR,
@@ -269,7 +267,7 @@ int iface_ethernet_ip_start(struct knot_thing thing,
 	disconn_cb = disconnected_cb;
 
 	connect_to = l_timeout_create_ms(1, attempt_connect,
-					 (void *) &type_connect, NULL);
+					 NULL, NULL);
 
 	return 0;
 }

--- a/src/iface-ethernet-ip.c
+++ b/src/iface-ethernet-ip.c
@@ -140,6 +140,17 @@ static void foreach_data_item_ethernet_ip(const void *key, void *value,
 	}
 }
 
+static void foreach_stop_ethernet_ip(const void *key, void *value,
+				      void *user_data)
+{
+	struct knot_data_item *data_item = value;
+	int *rc = user_data;
+
+	*rc = plc_tag_destroy(
+		data_item->ethernet_ip_data_settings.tag);
+
+}
+
 int iface_ethernet_ip_read_data(int tag, int reg_addr, uint8_t value_type,
 				int value_type_size,
 				knot_value_type *out)
@@ -225,4 +236,14 @@ int iface_ethernet_ip_start(struct knot_thing thing,
 	disconn_cb = disconnected_cb;
 
 	return 0;
+}
+
+void iface_ethernet_ip_stop(void)
+{
+	//TODO: Verify connection of ethernet/ip
+
+	int rc = 0;
+
+	l_hashmap_foreach(thing_ethernet_ip.data_items,
+			  foreach_stop_ethernet_ip, &rc);
 }

--- a/src/iface-ethernet-ip.c
+++ b/src/iface-ethernet-ip.c
@@ -1,0 +1,159 @@
+/**
+ * This file is part of the KNOT Project
+ *
+ * Copyright (c) 2021, CESAR. All rights reserved.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <libplctag.h>
+#include <ell/ell.h>
+#include <errno.h>
+#include <knot/knot_types.h>
+#include <knot/knot_protocol.h>
+
+#include "iface-ethernet-ip.h"
+#include "conf-driver.h"
+
+static iface_ethernet_ip_connected_cb_t conn_cb;
+static iface_ethernet_ip_disconnected_cb_t disconn_cb;
+
+struct knot_thing thing_ethernet_ip;
+
+#define REQUIRED_VERSION_MAJOR 2
+#define REQUIRED_VERSION_MINOR 1
+#define REQUIRED_VERSION_PATCH 4
+#define ETHERNET_IP_TEMPLATE_MODEL "protocol=ab-eip&gateway=%s&path=%s&cpu=%s&elem_count=%d&name=%s"
+#define DATA_TIMEOUT 500
+
+static void parse_tag_data_item(struct knot_data_item *data_item)
+{
+	struct knot_data_item data_item_aux;
+
+	snprintf(data_item_aux.ethernet_ip_data_settings.string_tag_path,
+		 512, ETHERNET_IP_TEMPLATE_MODEL,
+		 thing_ethernet_ip.geral_url,
+		 data_item->ethernet_ip_data_settings.path,
+		 thing_ethernet_ip.ethernet_ip_settings.plc_type,
+		 data_item->ethernet_ip_data_settings.element_size,
+		 data_item->ethernet_ip_data_settings.tag_name);
+	printf("%s\n\r",
+	       data_item_aux.ethernet_ip_data_settings.string_tag_path);
+
+	*data_item = data_item_aux;
+}
+
+static int verify_tag_name_created(struct knot_data_item *data_item)
+{
+	struct knot_data_item *data_item_aux;
+	int i;
+	int rc = -1;
+
+	for (i = 0; i < data_item->sensor_id; i++) {
+		int return_aux;
+
+		data_item_aux = l_hashmap_lookup(thing_ethernet_ip.data_items,
+						 L_INT_TO_PTR(i));
+		if (!data_item_aux)
+			rc = -EINVAL;
+
+		return_aux = strcmp(
+			data_item_aux->ethernet_ip_data_settings.tag_name,
+			data_item->ethernet_ip_data_settings.tag_name);
+		if (!return_aux) {
+			data_item->ethernet_ip_data_settings.tag =
+				data_item_aux->ethernet_ip_data_settings.tag;
+			rc = 0;
+			break;
+		}
+	}
+
+	return rc;
+}
+
+static int connect_ethernet_ip(struct knot_data_item *data_item)
+{
+	int rc = 0;
+
+	data_item->ethernet_ip_data_settings.tag = plc_tag_create(
+			data_item->ethernet_ip_data_settings.string_tag_path,
+			DATA_TIMEOUT);
+
+	if (data_item->ethernet_ip_data_settings.tag < 0) {
+		fprintf(stderr, "ERROR %s: Could not create tag %s!\n",
+			plc_tag_decode_error(
+				data_item->ethernet_ip_data_settings.tag),
+				data_item->ethernet_ip_data_settings.tag_name);
+		return -EINVAL;
+	}
+
+	rc = plc_tag_status(data_item->ethernet_ip_data_settings.tag);
+	if (rc != PLCTAG_STATUS_OK) {
+		fprintf(stderr, "Error setting up tag internal state. %s\n",
+			plc_tag_decode_error(
+				data_item->ethernet_ip_data_settings.tag));
+		return -EINVAL;
+	}
+
+	return rc;
+}
+
+static void foreach_data_item_ethernet_ip(const void *key, void *value,
+				      void *user_data)
+{
+	struct knot_data_item *data_item = value;
+	int *rc = user_data;
+	int return_aux = 0;
+
+	return_aux = verify_tag_name_created(data_item);
+	if (return_aux) {
+		parse_tag_data_item(data_item);
+		return_aux = connect_ethernet_ip(data_item);
+		if (return_aux) {
+			plc_tag_destroy(
+				data_item->ethernet_ip_data_settings.tag);
+			*rc = -EINVAL;
+		}
+	}
+}
+
+int iface_ethernet_ip_start(struct knot_thing thing,
+		       iface_ethernet_ip_connected_cb_t connected_cb,
+		       iface_ethernet_ip_disconnected_cb_t disconnected_cb,
+		       void *user_data)
+{
+	int rc = 0;
+
+	thing_ethernet_ip = thing;
+
+	if (plc_tag_check_lib_version(REQUIRED_VERSION_MAJOR,
+				      REQUIRED_VERSION_MINOR,
+				      REQUIRED_VERSION_PATCH)
+				      != PLCTAG_STATUS_OK) {
+		fprintf(stderr,
+			"Required compatible library version %d.%d.%d not available!",
+			REQUIRED_VERSION_MAJOR, REQUIRED_VERSION_MINOR,
+			REQUIRED_VERSION_PATCH);
+		return -EPERM;
+	}
+
+	l_hashmap_foreach(thing.data_items, foreach_data_item_ethernet_ip,
+			&rc);
+	if (rc)
+		return -EINVAL;
+
+	conn_cb = connected_cb;
+	disconn_cb = disconnected_cb;
+
+	return 0;
+}

--- a/src/iface-ethernet-ip.c
+++ b/src/iface-ethernet-ip.c
@@ -30,6 +30,19 @@ static iface_ethernet_ip_disconnected_cb_t disconn_cb;
 
 struct knot_thing thing_ethernet_ip;
 
+union ethernet_ip_types {
+	float val_float;
+	uint8_t val_bool;
+	int8_t val_i8;
+	uint8_t val_u8;
+	int16_t val_i16;
+	uint16_t val_u16;
+	int32_t val_i32;
+	uint32_t val_u32;
+	int64_t val_i64;
+	uint64_t val_u64;
+};
+
 #define REQUIRED_VERSION_MAJOR 2
 #define REQUIRED_VERSION_MINOR 1
 #define REQUIRED_VERSION_PATCH 4
@@ -125,6 +138,62 @@ static void foreach_data_item_ethernet_ip(const void *key, void *value,
 			*rc = -EINVAL;
 		}
 	}
+}
+
+int iface_ethernet_ip_read_data(int tag, int reg_addr, uint8_t value_type,
+				int value_type_size,
+				knot_value_type *out)
+{
+	int rc;
+	union ethernet_ip_types tmp;
+
+	memset(&tmp, 0, sizeof(tmp));
+
+	rc = plc_tag_read(tag, 100);
+
+	if (rc == PLCTAG_STATUS_OK) {
+		switch (value_type) {
+		//TODO: Update knot_cloud to accept int16
+		case KNOT_VALUE_TYPE_BOOL:
+			tmp.val_bool = plc_tag_get_uint8(tag, reg_addr);
+			break;
+		case KNOT_VALUE_TYPE_INT:
+			if (value_type_size == 8)
+				tmp.val_i8 = plc_tag_get_int8(tag, reg_addr);
+			else if (value_type_size == 16)
+				tmp.val_i16 = plc_tag_get_int16(tag, reg_addr);
+			else if (value_type_size == 32)
+				tmp.val_i32 = plc_tag_get_int32(tag, reg_addr);
+			else
+				rc = 1;
+			break;
+		case KNOT_VALUE_TYPE_UINT:
+			if (value_type_size == 8)
+				tmp.val_u8 = plc_tag_get_uint8(tag, reg_addr);
+			if (value_type_size == 16)
+				tmp.val_u16 = plc_tag_get_uint16(tag, reg_addr);
+			else if (value_type_size == 32)
+				tmp.val_u32 = plc_tag_get_uint32(tag, reg_addr);
+			else
+				rc = 1;
+			break;
+		case KNOT_VALUE_TYPE_INT64:
+			tmp.val_i64 = plc_tag_get_int64(tag, reg_addr);
+			break;
+		case KNOT_VALUE_TYPE_UINT64:
+			tmp.val_u64 = plc_tag_get_uint64(tag, reg_addr);
+			break;
+		default:
+			rc = -EINVAL;
+		}
+
+		memcpy(out, &tmp, sizeof(tmp));
+	} else {
+		l_error("Unable to read the data! Got error code %d: %s\n",
+			rc, plc_tag_decode_error(rc));
+	}
+
+	return rc;
 }
 
 int iface_ethernet_ip_start(struct knot_thing thing,

--- a/src/iface-ethernet-ip.h
+++ b/src/iface-ethernet-ip.h
@@ -1,0 +1,25 @@
+/**
+ * This file is part of the KNOT Project
+ *
+ * Copyright (c) 2021, CESAR. All rights reserved.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ */
+
+struct knot_thing;
+
+typedef void (*iface_ethernet_ip_connected_cb_t) (void *user_data);
+typedef void (*iface_ethernet_ip_disconnected_cb_t) (void *user_data);
+
+int iface_ethernet_ip_start(struct knot_thing thing,
+		       iface_ethernet_ip_connected_cb_t connected_cb,
+		       iface_ethernet_ip_disconnected_cb_t disconnected_cb,
+		       void *user_data);

--- a/src/iface-ethernet-ip.h
+++ b/src/iface-ethernet-ip.h
@@ -14,15 +14,10 @@
  *  Lesser General Public License for more details.
  */
 
-struct knot_thing;
-struct knot_value_type;
-
 typedef void (*iface_ethernet_ip_connected_cb_t) (void *user_data);
 typedef void (*iface_ethernet_ip_disconnected_cb_t) (void *user_data);
 
-int iface_ethernet_ip_read_data(int tag, int reg_addr, uint8_t value_type,
-				int value_type_size,
-				knot_value_type *out);
+int iface_ethernet_ip_read_data(struct knot_data_item *data_item);
 int iface_ethernet_ip_start(struct knot_thing thing,
 		       iface_ethernet_ip_connected_cb_t connected_cb,
 		       iface_ethernet_ip_disconnected_cb_t disconnected_cb,

--- a/src/iface-ethernet-ip.h
+++ b/src/iface-ethernet-ip.h
@@ -15,10 +15,14 @@
  */
 
 struct knot_thing;
+struct knot_value_type;
 
 typedef void (*iface_ethernet_ip_connected_cb_t) (void *user_data);
 typedef void (*iface_ethernet_ip_disconnected_cb_t) (void *user_data);
 
+int iface_ethernet_ip_read_data(int tag, int reg_addr, uint8_t value_type,
+				int value_type_size,
+				knot_value_type *out);
 int iface_ethernet_ip_start(struct knot_thing thing,
 		       iface_ethernet_ip_connected_cb_t connected_cb,
 		       iface_ethernet_ip_disconnected_cb_t disconnected_cb,

--- a/src/iface-ethernet-ip.h
+++ b/src/iface-ethernet-ip.h
@@ -27,3 +27,4 @@ int iface_ethernet_ip_start(struct knot_thing thing,
 		       iface_ethernet_ip_connected_cb_t connected_cb,
 		       iface_ethernet_ip_disconnected_cb_t disconnected_cb,
 		       void *user_data);
+void iface_ethernet_ip_stop(void);

--- a/src/iface-modbus.c
+++ b/src/iface-modbus.c
@@ -200,23 +200,23 @@ static void iface_modbus_config_endianness_type_recv_32_bits(uint32_t *src,
 				int endianness_type)
 {
 	switch (endianness_type) {
-	case MODBUS_ENDIANNESS_TYPE_BIG_ENDIAN:
+	case ENDIANNESS_TYPE_BIG_ENDIAN:
 		*src = ((*src & 0xffff0000u) >> 16)|
 			((*src & 0x0000ffffu) << 16);
 		break;
-	case MODBUS_ENDIANNESS_TYPE_MID_BIG_ENDIAN:
+	case ENDIANNESS_TYPE_MID_BIG_ENDIAN:
 		*src = ((((*src) & 0xff000000u) >> 24)|
 			(((*src) & 0x00ff0000u) >> 8)|
 			(((*src) & 0x0000ff00u) << 8)|
 			(((*src) & 0x000000ffu) << 24));
 		break;
-	case MODBUS_ENDIANNESS_TYPE_LITTLE_ENDIAN:
+	case ENDIANNESS_TYPE_LITTLE_ENDIAN:
 		*src = ((((*src) & 0xff000000u) >> 8)|
 			(((*src) & 0x00ff0000u) << 8)|
 			(((*src) & 0x0000ff00u) >> 8)|
 			(((*src) & 0x000000ffu) << 8));
 		break;
-	case MODBUS_ENDIANNESS_TYPE_MID_LITTLE_ENDIAN:
+	case ENDIANNESS_TYPE_MID_LITTLE_ENDIAN:
 		break;
 	default:
 		src = NULL;
@@ -227,8 +227,8 @@ static void iface_modbus_config_endianness_type_recv_32_bits(uint32_t *src,
 static void iface_modbus_config_endianness_type_recv_64_bits(uint64_t *src,
 				int endianness_type)
 {
-	if (endianness_type == MODBUS_ENDIANNESS_TYPE_MID_BIG_ENDIAN ||
-		endianness_type == MODBUS_ENDIANNESS_TYPE_LITTLE_ENDIAN){
+	if (endianness_type == ENDIANNESS_TYPE_MID_BIG_ENDIAN ||
+		endianness_type == ENDIANNESS_TYPE_LITTLE_ENDIAN){
 		*src = ((*src & 0xff00000000000000u) >> 8)|
 			((*src & 0x00ff000000000000u) << 8)|
 			((*src & 0x0000ff0000000000u) >> 8)|
@@ -238,8 +238,8 @@ static void iface_modbus_config_endianness_type_recv_64_bits(uint64_t *src,
 			((*src & 0x000000000000ff00u) >> 8)|
 			((*src & 0x00000000000000ffu) << 8);
 	}
-	if (endianness_type == MODBUS_ENDIANNESS_TYPE_MID_BIG_ENDIAN ||
-		endianness_type == MODBUS_ENDIANNESS_TYPE_BIG_ENDIAN){
+	if (endianness_type == ENDIANNESS_TYPE_MID_BIG_ENDIAN ||
+		endianness_type == ENDIANNESS_TYPE_BIG_ENDIAN){
 		*src = ((*src & 0xffff000000000000u) >> 48)|
 			((*src & 0x0000ffff00000000u) >> 16)|
 			((*src & 0x00000000ffff0000u) << 16)|
@@ -281,6 +281,7 @@ int iface_modbus_read_data(int reg_addr, int bit_offset, knot_value_type *out,
 		iface_modbus_config_endianness_type_recv_32_bits(&tmp.val_u32,
 						endianness_type);
 		break;
+
 	case TYPE_U64:
 		rc = modbus_read_registers(modbus_ctx, reg_addr, 4,
 					   (uint16_t *) &tmp.val_u64);

--- a/src/iface-modbus.c
+++ b/src/iface-modbus.c
@@ -309,7 +309,6 @@ int iface_modbus_start(const char *url, int slave_id,
 		       iface_modbus_disconnected_cb_t disconnected_cb,
 		       void *user_data)
 {
-	enum CONN_TYPE type_connect = MODBUS;
 	modbus_ctx = create_ctx(url);
 	if (!modbus_ctx)
 		return -errno;
@@ -321,7 +320,7 @@ int iface_modbus_start(const char *url, int slave_id,
 	disconn_cb = disconnected_cb;
 
 	connect_to = l_timeout_create_ms(1, attempt_connect,
-					 (void *) &type_connect, NULL);
+					 NULL, NULL);
 
 	return 0;
 }

--- a/src/iface-modbus.c
+++ b/src/iface-modbus.c
@@ -32,6 +32,7 @@
 #include <asm-generic/ioctls.h>
 
 #include "conf-parameters.h"
+#include "conf-driver.h"
 #include "iface-modbus.h"
 
 #define TCP_PREFIX "tcp://"
@@ -176,7 +177,7 @@ static void attempt_connect(struct l_timeout *to, void *user_data)
 	if (!modbus_io)
 		goto connection_close;
 
-	if (!l_io_set_disconnect_handler(modbus_io, on_disconnected, NULL,
+	if (!l_io_set_disconnect_handler(modbus_io, on_disconnected, user_data,
 					 NULL)) {
 		l_error("Couldn't set Modbus disconnect handler");
 		goto io_destroy;
@@ -308,6 +309,7 @@ int iface_modbus_start(const char *url, int slave_id,
 		       iface_modbus_disconnected_cb_t disconnected_cb,
 		       void *user_data)
 {
+	enum CONN_TYPE type_connect = MODBUS;
 	modbus_ctx = create_ctx(url);
 	if (!modbus_ctx)
 		return -errno;
@@ -318,7 +320,8 @@ int iface_modbus_start(const char *url, int slave_id,
 	conn_cb = connected_cb;
 	disconn_cb = disconnected_cb;
 
-	connect_to = l_timeout_create_ms(1, attempt_connect, NULL, NULL);
+	connect_to = l_timeout_create_ms(1, attempt_connect,
+					 (void *) &type_connect, NULL);
 
 	return 0;
 }

--- a/src/iface-modbus.h
+++ b/src/iface-modbus.h
@@ -14,15 +14,11 @@
  *  Lesser General Public License for more details.
  */
 
-extern struct modbus_driver tcp;
-extern struct modbus_driver rtu;
-
 typedef void (*iface_modbus_connected_cb_t) (void *user_data);
 typedef void (*iface_modbus_disconnected_cb_t) (void *user_data);
 
-int iface_modbus_read_data(int reg_addr, int bit_offset, knot_value_type *out,
-			   int endianness_type);
-int iface_modbus_start(const char *url, int slave_id,
+int iface_modbus_read_data(struct knot_data_item *data_item);
+int iface_modbus_start(struct knot_thing thing,
 		       iface_modbus_connected_cb_t connected_cb,
 		       iface_modbus_disconnected_cb_t disconnected_cb,
 		       void *user_data);

--- a/src/main.c
+++ b/src/main.c
@@ -32,7 +32,7 @@
 
 #include "settings.h"
 #include "device.h"
-#include "conf-driver.h"
+#include "conf-device.h"
 
 static int log_priority;
 
@@ -55,20 +55,20 @@ static int detach_daemon(void)
 	return 0;
 }
 
-static void set_device_settings(struct device_settings *conf_files,
-				struct settings *settings)
+static void set_device_settings(struct device_settings *device_settings,
+								struct settings *settings)
 {
-	conf_files->credentials_path = l_strdup(settings->credentials_path);
-	conf_files->device_path = l_strdup(settings->device_path);
-	conf_files->cloud_path = l_strdup(settings->cloud_path);
+	device_settings->credentials_path = l_strdup(settings->credentials_path);
+	device_settings->device_path = l_strdup(settings->device_path);
+	device_settings->cloud_path = l_strdup(settings->cloud_path);
 }
 
-static void free_device_settings(struct device_settings *conf_files)
+static void free_device_settings(struct device_settings *device_settings)
 {
-	l_free(conf_files->credentials_path);
-	l_free(conf_files->device_path);
-	l_free(conf_files->cloud_path);
-	l_free(conf_files);
+	l_free(device_settings->credentials_path);
+	l_free(device_settings->device_path);
+	l_free(device_settings->cloud_path);
+	l_free(device_settings);
 }
 
 static void log_stderr_handler(int priority, const char *file, const char *line,
@@ -111,7 +111,7 @@ static void log_enable(int priority)
 int main(int argc, char *argv[])
 {
 	struct settings *settings;
-	struct device_settings *conf_files;
+	struct device_settings *device_settings;
 	int err;
 
 	settings = settings_load(argc, argv);
@@ -130,21 +130,21 @@ int main(int argc, char *argv[])
 
 	log_enable(settings->log_level);
 
-	conf_files = l_new(struct device_settings, 1);
-	set_device_settings(conf_files, settings);
+	device_settings = l_new(struct device_settings, 1);
+	set_device_settings(device_settings, settings);
 
 	l_info("Starting KNoT VirtualThing");
 
-	err = device_start(conf_files);
+	err = device_start(device_settings);
 	if (err) {
 		l_error("Failed to start the device: %s (%d). Exiting...",
 			strerror(-err), -err);
 		l_main_exit();
 		settings_free(settings);
-		free_device_settings(conf_files);
+		free_device_settings(device_settings);
 		return EXIT_FAILURE;
 	}
-	free_device_settings(conf_files);
+	free_device_settings(device_settings);
 
 	if (settings->detach) {
 		err = detach_daemon();

--- a/src/main.c
+++ b/src/main.c
@@ -32,6 +32,7 @@
 
 #include "settings.h"
 #include "device.h"
+#include "conf-driver.h"
 
 static int log_priority;
 

--- a/src/properties.c
+++ b/src/properties.c
@@ -30,6 +30,7 @@
 #include "properties.h"
 #include "storage.h"
 #include "conf-parameters.h"
+#include "conf-driver.h"
 
 #define EMPTY_STRING ""
 

--- a/src/properties.c
+++ b/src/properties.c
@@ -107,14 +107,14 @@ static int set_rabbit_mq_url(struct knot_thing *thing, int rabbitmq_fd)
 	return 0;
 }
 
-static int valid_bit_offset(int bit_offset, int value_type)
+static int valid_bit_size(int bit_size, int value_type)
 {
 	int value_type_mask;
 	int valid_value_type_mask;
 
 	value_type_mask = 1 << value_type;
 
-	switch (bit_offset) {
+	switch (bit_size) {
 	case 1:
 		valid_value_type_mask = (1 << KNOT_VALUE_TYPE_BOOL);
 		break;
@@ -142,39 +142,77 @@ static int valid_bit_offset(int bit_offset, int value_type)
 	return 0;
 }
 
-static int set_modbus_source_properties(struct knot_thing *thing,
-					int fd, char *group_id,
-					knot_schema schema,
-					int *reg_addr, int *bit_offset,
-					int *endianness_type)
+static int set_data_properties(struct knot_thing *thing,
+			       int fd, char *group_id,
+			       knot_schema schema,
+			       int *reg_addr, int *bit_size,
+			       int *endianness_type)
 {
 	int rc;
 	int reg_addr_aux;
-	int bit_offset_aux;
+	int bit_size_aux;
 	int endianness_type_aux;
 
-	rc = storage_read_key_int(fd, group_id, MODBUS_REG_ADDRESS,
+	rc = storage_read_key_int(fd, group_id, DATA_REG_ADDRESS,
 				  &reg_addr_aux);
 	if (rc <= 0)
 		return -EINVAL;
 
-	rc = storage_read_key_int(fd, group_id, MODBUS_TYPE_ENDIANNESS,
+	rc = storage_read_key_int(fd, group_id, DATA_TYPE_ENDIANNESS,
 				  &endianness_type_aux);
 	if (rc <= 0)
 		return -EINVAL;
 
-	rc = storage_read_key_int(fd, group_id, MODBUS_BIT_OFFSET,
-				  &bit_offset_aux);
+	rc = storage_read_key_int(fd, group_id, DATA_VALUE_TYPE_SIZE,
+				  &bit_size_aux);
 	if (rc <= 0)
 		return -EINVAL;
 
-	rc = valid_bit_offset(bit_offset_aux, schema.value_type);
+	rc = valid_bit_size(bit_size_aux, schema.value_type);
 	if (rc < 0)
 		return -EINVAL;
 
-	*bit_offset = bit_offset_aux;
+	*bit_size = bit_size_aux;
 	*reg_addr = reg_addr_aux;
 	*endianness_type = endianness_type_aux;
+
+	return 0;
+}
+
+static int set_ethernet_ip_source_properties(struct knot_thing *thing,
+				int fd, char *group_id,
+				struct ethernet_ip_data_settings *ethernet_ip)
+{
+	int rc;
+	char *tag_name_aux;
+	char *path_aux;
+	int element_size_aux;
+	struct ethernet_ip_data_settings ethernet_ip_prop;
+
+	tag_name_aux = storage_read_key_string(fd, group_id,
+					       ETHERNET_IP_TAG_NAME);
+	if (tag_name_aux == NULL || !strcmp(tag_name_aux, "") ||
+			strlen(tag_name_aux) >= ETHERNET_IP_MAX_TYPE_TAG_LEN)
+		return -EINVAL;
+	strcpy(ethernet_ip_prop.tag_name, tag_name_aux);
+	l_free(tag_name_aux);
+
+	path_aux = storage_read_key_string(fd, group_id, ETHERNET_IP_PATH);
+	if (path_aux == NULL || !strcmp(path_aux, "") ||
+			strlen(path_aux) >= ETHERNET_IP_MAX_TYPE_PATH_LEN)
+		return -EINVAL;
+
+	strcpy(ethernet_ip_prop.path, path_aux);
+	l_free(path_aux);
+
+	rc = storage_read_key_int(fd, group_id, ETHERNET_IP_ELEMENT_SIZE,
+				  &element_size_aux);
+	if (rc <= 0)
+		return -EINVAL;
+
+	ethernet_ip_prop.element_size = element_size_aux;
+
+	*ethernet_ip = ethernet_ip_prop;
 
 	return 0;
 }
@@ -445,7 +483,7 @@ static int set_data_items(struct knot_thing *thing, int fd)
 	int endianness_type;
 	knot_schema schema;
 	knot_event event;
-
+	struct ethernet_ip_data_settings ethernet_ip;
 	data_item_group = get_data_item_groups(fd);
 
 	if (!data_item_group) {
@@ -475,18 +513,29 @@ static int set_data_items(struct knot_thing *thing, int fd)
 			goto error;
 		}
 
-		rc = set_modbus_source_properties(thing, fd, data_item_group[i],
+		rc = set_data_properties(thing, fd, data_item_group[i],
 						  schema, &reg_addr,
 						  &bit_offset,
 						  &endianness_type);
 		if (rc < 0) {
-			l_error("Failed to set Modbus Source properties on %s",
+			l_error("Failed to set Data properties on %s",
 				data_item_group[i]);
 			goto error;
 		}
+#if DRIVER_ETHERNET_IP
+		rc = set_ethernet_ip_source_properties(thing, fd,
+					data_item_group[i],
+					&ethernet_ip);
+		if (rc < 0) {
+			l_error("Failed to set Ethernet/IP Source properties on %s",
+				data_item_group[i]);
+			goto error;
+		}
+#endif
 
 		device_set_new_data_item(thing, sensor_id, schema, event,
-					 reg_addr, bit_offset, endianness_type);
+					 reg_addr, bit_offset, endianness_type,
+					 &ethernet_ip);
 	}
 
 	l_strfreev(data_item_group);
@@ -504,7 +553,6 @@ static int set_modbus_slave_properties(struct knot_thing *thing, int fd)
 	int rc;
 	int aux;
 	int id;
-	char *url;
 
 	rc = storage_read_key_int(fd, THING_GROUP, THING_MODBUS_SLAVE_ID, &aux);
 	if (rc <= 0)
@@ -515,12 +563,26 @@ static int set_modbus_slave_properties(struct knot_thing *thing, int fd)
 
 	id = aux;
 
-	url = storage_read_key_string(fd, THING_GROUP, THING_MODBUS_URL);
-	if (url == NULL || !strcmp(url, ""))
-		return -EINVAL;
-	/* TODO: Check if modbus url is in a valid format */
+	device_set_thing_modbus_slave(thing, id);
 
-	device_set_thing_modbus_slave(thing, id, url);
+	return 0;
+}
+
+static int set_ethernet_ip_slave_properties(struct knot_thing *thing,
+					    int fd)
+{
+	char *plc_type;
+
+	plc_type = storage_read_key_string(fd, THING_GROUP,
+					   THING_ETHERNET_IP_PLC_TYPE);
+	if (plc_type == NULL || !strcmp(plc_type, "") ||
+		strlen(plc_type) >= THING_ETHERNET_IP_MAX_TYPE_PLC_LEN) {
+		l_free(plc_type);
+		return -EINVAL;
+	}
+
+	device_set_thing_ethernet_ip_slave(thing, plc_type);
+	l_free(plc_type);
 
 	return 0;
 }
@@ -556,6 +618,21 @@ static int set_thing_name(struct knot_thing *thing, int fd)
 	return 0;
 }
 
+static int set_thing_url(struct knot_thing *thing, int fd)
+{
+	char *thing_url;
+
+	thing_url = storage_read_key_string(fd, THING_GROUP, THING_URL);
+	if (thing_url == NULL || !strcmp(thing_url, ""))
+		return -EINVAL;
+	/* TODO: Check if modbus url is in a valid format */
+
+	device_set_thing_url(thing, thing_url);
+	l_free(thing_url);
+
+	return 0;
+}
+
 static int set_thing_properties(struct knot_thing *thing, char *filename)
 {
 	int device_fd;
@@ -574,9 +651,20 @@ static int set_thing_properties(struct knot_thing *thing, char *filename)
 		return rc;
 	}
 
-	rc = set_modbus_slave_properties(thing, device_fd);
+	rc = set_thing_url(thing, device_fd);
 	if (rc < 0) {
-		l_error("Failed to set Modbus Slave properties");
+		l_error("Failed to set Thing URL");
+		storage_close(device_fd);
+		return rc;
+	}
+
+#if	DRIVER_MODBUS
+	rc = set_modbus_slave_properties(thing, device_fd);
+#elif	DRIVER_ETHERNET_IP
+	rc = set_ethernet_ip_slave_properties(thing, device_fd);
+#endif
+	if (rc < 0) {
+		l_error("Failed to set driver properties");
 		storage_close(device_fd);
 		return rc;
 	}

--- a/src/properties.h
+++ b/src/properties.h
@@ -19,7 +19,7 @@
  */
 
 int properties_create_device(struct knot_thing *thing,
-			     struct device_settings *conf_files);
+			     struct device_settings *settings);
 
 int properties_clear_credentials(struct knot_thing *thing, char *filename);
 int properties_store_credentials(struct knot_thing *thing, char *filename,

--- a/src/settings.c
+++ b/src/settings.c
@@ -94,7 +94,7 @@ static int parse_args(int argc, char *argv[], struct settings *settings)
 	int opt;
 
 	for (;;) {
-		opt = getopt_long(argc, argv, "c:d:p:l:nh",
+		opt = getopt_long(argc, argv, "P:c:d:p:l:nh",
 				  main_options, NULL);
 		if (opt < 0)
 			break;


### PR DESCRIPTION
Add Ethernet/IP protocol by doing the following changes:

- Change structure to accept multiple drivers;
- Add driver flow;
- Add driver files;
- Change parameters to accept Ethernet/IP configuration;
- Add iface-ethernet-ip files;
- Add read flow for Ethernet/IP;
- Add connect flow for Ethernet/IP;
- Add disconnect flow for Ethernet/IP.