### PR TITLE
Add configuration documentation with EtherNet/IP

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,6 +18,7 @@ src_thingd_SOURCES = src/main.c \
 			src/storage.c src/storage.h \
 			src/iface-modbus.c src/iface-modbus.h \
 			src/iface-ethernet-ip.c src/iface-ethernet-ip.h \
+			src/driver.c src/driver.h \
 			src/settings.c src/settings.h \
 			src/event.c src/event.h \
 			src/poll.c src/poll.h \

--- a/confs/device.conf
+++ b/confs/device.conf
@@ -6,13 +6,33 @@
 [KNoTThing]
 
 Name = Thing Name
-ModbusSlaveId = 1
-# KNoT Virtual Thing supports both Modbus RTU and Modbus TCP
-# ATTENTION: The connection type is defined by the URL prefix
-# TCP prefix - tcp://
-# RTU prefix - serial://
-ModbusURL = tcp://127.0.0.1:502
-# ModbusURL = serial:///dev/ttyUSB0:115200,N,8,1
+DeviceId = 1
+
+# KNoT Virtual Thing supports Modbus RTU, Modbus TCP and Ethernet/IP
+DeviceProtocolType = ETHERNET/IP
+# DeviceProtocolType = MODBUS
+
+# ATTENTION: Modbus connection type is defined by URL prefix and Ethernet/IP
+# does not need prefix.
+# Modbus TCP prefix - tcp://
+# Modbus RTU prefix - serial://
+DriverURL = 127.0.0.1
+# DriverURL = tcp://127.0.0.1:502
+# DriverURL = serial:///dev/ttyUSB0:115200,N,8,1
+
+# ATTENTION: It is possible for you to identify what type of endianness
+# is being used.
+# ENDIANNESS_TYPE_BIG_ENDIAN		HEX: 0x01	INT: 1
+# ENDIANNESS_TYPE_MID_BIG_ENDIAN	HEX: 0x02	INT: 2
+# ENDIANNESS_TYPE_LITTLE_ENDIAN		HEX: 0x03	INT: 3
+# ENDIANNESS_TYPE_MID_LITTLE_ENDIAN	HEX: 0x04	INT: 4
+TypeEndianness = 1
+
+#ATTETION: Only for ethernet/ip you need to specify the PLC type.
+# It is possible to see the models available in the link below:
+# https://github.com/libplctag/libplctag/wiki/Tag-String-Attributes
+# AB-Specific Attributes -> plc
+DeviceNameType = ControlLogix
 
 ####################### KNoT Data Items Parameters #############################
 
@@ -23,6 +43,8 @@ ModbusURL = tcp://127.0.0.1:502
 
 # ATTENTION: Sensor Id, Value Type, Unit and Type Id ONLY supports integers
 # values.
+# ATTENTION: For the SchemaSensorId it is necessary to maintain an ascending
+# order without gaps. For example: 0,1,2,3,4.
 # The possible combinations of these parameters are specified in the link below:
 # https://knot-devel.cesar.org.br/doc/thing/unit-type-value.html
 # Data_Item_0 has the following specifications:
@@ -35,15 +57,28 @@ SchemaTypeId = 1
 SchemaUnit = 1
 SchemaValueType = 1
 
-ModbusRegisterAddress = 200
-# Possible bit offset values are:
+# ATTENTION: Tag name, path and element size ONLY used for Ethernet/IP communication.
+DataTagName = F8
+DataIpPath = 1,0
+DataIpElementSize = 1000
+
+# DataItem Address.
+# ATTENTION: For EtherNet/IP address can be added directly in
+# DataTagName and RegisterAddress will be 0.
+# Possible values are:
+# RegisterAddress = 0
+# DataTagName = F8[1].1
+RegisterAddress = 6
+
+# Possible bit values are:
 # 1 - bit
 # 8 - byte
 # 16 - uint16
 # 32 - uint32
 # 64 - uint64
-# ATTENTION: Bit offset must be synchronized with Type ID.
-ModbusBitOffset = 16
+# ATTENTION: Bit must be synchronized with Type ID for Modbus.
+ValueTypeSize = 16
+
 
 # ATTENTION: Only specify the event parameters that are going to be used in
 # this data item.
@@ -53,21 +88,22 @@ EventLowerThreshold = 1000
 EventUpperThreshold = 3000
 EventTimeSec = 5
 
-# Following the notation specified previously, the second data item in this
-# configuration file is DataItem_1, which has the follow specifications:
-# KNOT_TYPE_ID_SWITCH		HEX: 0xFFF1	INT: 65521
-# KNOT_UNIT_NOT_APPLICABLE	HEX: 0x00	INT: 0
-# KNOT_VALUE_TYPE_BOOL		HEX: 0x03	INT: 3
 [DataItem_1]
+
+
+DataTagName = F8
+DataIpPath = 1,0
+DataIpElementSize = 1000
+
+RegisterAddress = 8
+
+ValueTypeSize = 32
 
 SchemaSensorId = 1
 SchemaSensorName = KNoTSensor_1
-SchemaTypeId = 65521
-SchemaUnit = 0
-SchemaValueType = 3
-
-ModbusRegisterAddress = 0
-ModbusBitOffset = 1
+SchemaTypeId = 65296
+SchemaUnit = 1
+SchemaValueType = 2
 
 # This data item will send a publish data event every 5 seconds or when its
 # value has changed.

--- a/src/device.c
+++ b/src/device.c
@@ -53,7 +53,6 @@ static void knot_thing_destroy(struct knot_thing *thing)
 
 	l_free(thing->user_token);
 	l_free(thing->rabbitmq_url);
-	l_free(thing->geral_url);
 	l_free(thing->conf_files.credentials_path);
 	l_free(thing->conf_files.device_path);
 	l_free(thing->conf_files.cloud_path);

--- a/src/iface-ethernet-ip.c
+++ b/src/iface-ethernet-ip.c
@@ -193,55 +193,71 @@ int iface_ethernet_ip_read_data(struct knot_data_item *data_item)
 {
 	int rc;
 	union ethernet_ip_types tmp;
+	int elem_size = 0;
 
 	memset(&tmp, 0, sizeof(tmp));
 
-	rc = plc_tag_read(data_item->tag, 100);
+	rc = plc_tag_read(data_item->tag, DATA_TIMEOUT);
 
 	if (rc == PLCTAG_STATUS_OK) {
+		elem_size = plc_tag_get_int_attribute(data_item->tag,
+						      "elem_size", 0);
 		switch (data_item->schema.value_type) {
 		//TODO: Update knot_cloud to accept int16
 		case KNOT_VALUE_TYPE_BOOL:
-			tmp.val_bool = plc_tag_get_uint8(data_item->tag,
-							 data_item->reg_addr);
+			if (data_item->value_type_size == 1)
+				tmp.val_bool = (uint8_t)
+					plc_tag_get_bit(data_item->tag, 0);
+			else if (data_item->value_type_size == 8)
+				tmp.val_bool =
+					plc_tag_get_uint8(data_item->tag,
+					    data_item->reg_addr * elem_size);
+			else
+				rc = 1;
 			break;
 		case KNOT_VALUE_TYPE_FLOAT:
 			tmp.val_float = plc_tag_get_float32(data_item->tag,
-							data_item->reg_addr);
+					    data_item->reg_addr * elem_size);
 			break;
 		case KNOT_VALUE_TYPE_INT:
 			if (data_item->value_type_size == 8)
-				tmp.val_i8 = plc_tag_get_int8(data_item->tag,
-							data_item->reg_addr);
+				tmp.val_i8 =
+					plc_tag_get_int8(data_item->tag,
+					    data_item->reg_addr * elem_size);
 			else if (data_item->value_type_size == 16)
-				tmp.val_i16 = plc_tag_get_int16(data_item->tag,
-							data_item->reg_addr);
+				tmp.val_i16 =
+					plc_tag_get_int16(data_item->tag,
+					    data_item->reg_addr * elem_size);
 			else if (data_item->value_type_size == 32)
-				tmp.val_i32 = plc_tag_get_int32(data_item->tag,
-							data_item->reg_addr);
+				tmp.val_i32 =
+					plc_tag_get_int32(data_item->tag,
+					    data_item->reg_addr * elem_size);
 			else
 				rc = 1;
 			break;
 		case KNOT_VALUE_TYPE_UINT:
 			if (data_item->value_type_size == 8)
-				tmp.val_u8 = plc_tag_get_uint8(data_item->tag,
-							data_item->reg_addr);
+				tmp.val_u8 =
+					plc_tag_get_uint8(data_item->tag,
+					    data_item->reg_addr * elem_size);
 			if (data_item->value_type_size == 16)
-				tmp.val_u16 = plc_tag_get_uint16(data_item->tag,
-							data_item->reg_addr);
+				tmp.val_u16 =
+					plc_tag_get_uint16(data_item->tag,
+					    data_item->reg_addr * elem_size);
 			else if (data_item->value_type_size == 32)
-				tmp.val_u32 = plc_tag_get_uint32(data_item->tag,
-							data_item->reg_addr);
+				tmp.val_u32 =
+					plc_tag_get_uint32(data_item->tag,
+					    data_item->reg_addr * elem_size);
 			else
 				rc = 1;
 			break;
 		case KNOT_VALUE_TYPE_INT64:
 			tmp.val_i64 = plc_tag_get_int64(data_item->tag,
-						data_item->reg_addr);
+					data_item->reg_addr * elem_size);
 			break;
 		case KNOT_VALUE_TYPE_UINT64:
 			tmp.val_u64 = plc_tag_get_uint64(data_item->tag,
-						data_item->reg_addr);
+					data_item->reg_addr * elem_size);
 			break;
 		default:
 			rc = -EINVAL;

--- a/src/properties.c
+++ b/src/properties.c
@@ -121,6 +121,8 @@ static int valid_bit_size(int bit_size, int value_type)
 		valid_value_type_mask = (1 << KNOT_VALUE_TYPE_BOOL);
 		break;
 	case 8:
+		valid_value_type_mask = (1 << KNOT_VALUE_TYPE_BOOL);
+		break;
 		/* KNoT Protocol doesn't have a matching value type */
 	case 16:
 		/* KNoT Protocol doesn't have a matching value type */


### PR DESCRIPTION
Add configuration documentation with EtherNet/IP:
- Added driver file to makefile;
- Added element size to ethernet/ip read;
- Added KNoT value type bool to 8 bits size;
- Added documentation for device.conf.