### PR TITLE
Add cloud message ID condition protection

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -142,41 +142,49 @@ static void on_event_timeout(int id)
 
 static bool on_cloud_receive(const struct knot_cloud_msg *msg, void *user_data)
 {
-	switch (msg->type) {
-	case UPDATE_MSG:
-		if (!msg->error)
-			sm_input_event(EVT_DATA_UPDT, msg->list);
-		break;
-	case REQUEST_MSG:
-		if (!msg->error)
-			sm_input_event(EVT_PUB_DATA, msg->list);
-		break;
-	case REGISTER_MSG:
-		if (msg->error)
-			sm_input_event(EVT_REG_NOT_OK, NULL);
-		else
-			sm_input_event(EVT_REG_OK, (char *) msg->token);
-		break;
-	case UNREGISTER_MSG:
-		if (!msg->error)
-			sm_input_event(EVT_UNREG_REQ, (char *) msg->id);
-		break;
-	case AUTH_MSG:
+	int return_id = -EINVAL;
+
+	return_id = strcmp(msg->device_id, thing.id);
+	if (msg->type == AUTH_MSG)
+	{
 		if (msg->error)
 			sm_input_event(EVT_AUTH_NOT_OK, NULL);
 		else
 			sm_input_event(EVT_AUTH_OK, NULL);
-		break;
-	case CONFIG_MSG:
-		if (msg->error)
-			sm_input_event(EVT_CFG_UPT_NOT_OK, NULL);
-		else
-			sm_input_event(EVT_CFG_UPT_OK, msg->list);
-		break;
-	case LIST_MSG:
-	case MSG_TYPES_LENGTH:
-	default:
-		return true;
+	} else if (!return_id) {
+		switch (msg->type) {
+		case UPDATE_MSG:
+			if (!msg->error)
+				sm_input_event(EVT_DATA_UPDT, msg->list);
+			break;
+		case REQUEST_MSG:
+			if (!msg->error)
+				sm_input_event(EVT_PUB_DATA, msg->list);
+			break;
+		case REGISTER_MSG:
+			if (msg->error)
+				sm_input_event(EVT_REG_NOT_OK, NULL);
+			else
+				sm_input_event(EVT_REG_OK, (char *) msg->token);
+			break;
+		case UNREGISTER_MSG:
+			if (!msg->error)
+				sm_input_event(EVT_UNREG_REQ, (char *) msg->id);
+			break;
+		case AUTH_MSG:
+
+			break;
+		case CONFIG_MSG:
+			if (msg->error)
+				sm_input_event(EVT_CFG_UPT_NOT_OK, NULL);
+			else
+				sm_input_event(EVT_CFG_UPT_OK, msg->list);
+			break;
+		case LIST_MSG:
+		case MSG_TYPES_LENGTH:
+		default:
+			return true;
+		}
 	}
 
 	return true;


### PR DESCRIPTION
Add cloud message ID condition protection by doing the following changes:

- Added condition to identify message ID received from knot cloud;
- Comparing the device id with the id received from knot cloud.