### PR TITLE
Add double variable for OPC UA Protocol

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -57,6 +57,16 @@ static int compare_float(float val1, float val2)
 	return 0;
 }
 
+static int compare_double(double val1, double val2)
+{
+	if (val1 < val2)
+		return -1;
+	if (val1 > val2)
+		return 1;
+
+	return 0;
+}
+
 static int compare_bool(bool val1, bool val2)
 {
 	if (val1 == false && val2 == true)
@@ -90,6 +100,9 @@ static int compare_knot_value(knot_value_type val1, knot_value_type val2,
 		break;
 	case KNOT_VALUE_TYPE_RAW:
 		rc = compare_raw(val1.raw, val2.raw);
+		break;
+	case KNOT_VALUE_TYPE_DOUBLE:
+		rc = compare_double(val1.val_d, val2.val_d);
 		break;
 	default:
 		rc = 1;

--- a/src/iface-opc-ua.c
+++ b/src/iface-opc-ua.c
@@ -61,6 +61,7 @@ static UA_Client *opc_ua_client;
 union opc_ua_types {
 	uint8_t val_raw[KNOT_DATA_RAW_SIZE];
 	float val_float;
+	double val_double;
 	uint8_t val_bool;
 	int8_t val_i8;
 	uint8_t val_u8;
@@ -211,6 +212,18 @@ static void get_type_float(union opc_ua_types *tmp,
 	}
 }
 
+static void get_type_double(union opc_ua_types *tmp,
+				    UA_Variant *data,
+				    int value_type_size)
+{
+	if (value_type_size == 64) {
+		if (UA_Variant_hasScalarType(data,
+				&UA_TYPES[UA_TYPES_DOUBLE])) {
+			tmp->val_double = *(UA_Double *)data->data;
+		}
+	}
+}
+
 static void get_type_bool(union opc_ua_types *tmp,
 				    UA_Variant *data,
 				    int value_type_size)
@@ -260,6 +273,9 @@ static void get_read_value(UA_Variant *value,
 		break;
 	case KNOT_VALUE_TYPE_RAW:
 		get_type_raw(tmp, value);
+		break;
+	case KNOT_VALUE_TYPE_DOUBLE:
+		get_type_double(tmp, value, value_type_size);
 		break;
 	default:
 		break;

--- a/src/properties.c
+++ b/src/properties.c
@@ -138,7 +138,7 @@ static int valid_bit_size(int bit_size, int value_type)
 	case 64:
 		valid_value_type_mask = (1 << KNOT_VALUE_TYPE_INT64) |
 					(1 << KNOT_VALUE_TYPE_UINT64) |
-					(1 << KNOT_VALUE_TYPE_FLOAT);
+					(1 << KNOT_VALUE_TYPE_DOUBLE);
 		break;
 	default:
 		return -EINVAL;
@@ -245,6 +245,7 @@ static int get_upper_limit(int fd, char *group_id, int value_type,
 	int rc;
 	knot_value_type_int val_i;
 	knot_value_type_float val_f;
+	knot_value_type_double val_d;
 	knot_value_type_bool val_b;
 	knot_value_type_int64 val_i64;
 	knot_value_type_uint val_u;
@@ -286,6 +287,12 @@ static int get_upper_limit(int fd, char *group_id, int value_type,
 		break;
 	case KNOT_VALUE_TYPE_RAW:
 		/* Storage doesn't give support to raw */
+	case KNOT_VALUE_TYPE_DOUBLE:
+		rc = storage_read_key_double(fd, group_id,
+					    EVENT_UPPER_THRESHOLD,
+					    &val_d);
+		temp->val_d = val_d;
+		break;
 	default:
 		return -EINVAL;
 	}
@@ -299,6 +306,7 @@ static int get_lower_limit(int fd, char *group_id, int value_type,
 	int rc;
 	knot_value_type_int val_i;
 	knot_value_type_float val_f;
+	knot_value_type_double val_d;
 	knot_value_type_bool val_b;
 	knot_value_type_int64 val_i64;
 	knot_value_type_uint val_u;
@@ -340,6 +348,12 @@ static int get_lower_limit(int fd, char *group_id, int value_type,
 		break;
 	case KNOT_VALUE_TYPE_RAW:
 		/* Storage doesn't give support to raw */
+	case KNOT_VALUE_TYPE_DOUBLE:
+		rc = storage_read_key_double(fd, group_id,
+					    EVENT_LOWER_THRESHOLD,
+					    &val_d);
+		temp->val_d = val_d;
+		break;
 	default:
 		return -EINVAL;
 	}
@@ -373,6 +387,9 @@ static int set_limit(int fd, const char *group_id, const char *key,
 		break;
 	case KNOT_VALUE_TYPE_RAW:
 		/* Storage doesn't give support to raw */
+	case KNOT_VALUE_TYPE_DOUBLE:
+		rc = storage_write_key_double(fd, group_id, key, value.val_f);
+		break;
 	default:
 		return -EINVAL;
 	}

--- a/src/storage.c
+++ b/src/storage.c
@@ -329,6 +329,33 @@ int storage_write_key_float(int fd, const char *group, const char *key,
 	return save_settings(fd, settings);
 }
 
+int storage_read_key_double(int fd, const char *group, const char *key,
+			   double *value)
+{
+	struct l_settings *settings;
+
+	settings = l_hashmap_lookup(storage_list, L_INT_TO_PTR(fd));
+	if (!settings)
+		return -EINVAL;
+
+	return l_settings_get_double(settings, group, key, value);
+}
+
+int storage_write_key_double(int fd, const char *group, const char *key,
+			    double value)
+{
+	struct l_settings *settings;
+
+	settings = l_hashmap_lookup(storage_list, L_INT_TO_PTR(fd));
+	if (!settings)
+		return -EINVAL;
+
+	if (l_settings_set_double(settings, group, key, value) == false)
+		return -EINVAL;
+
+	return save_settings(fd, settings);
+}
+
 int storage_read_key_bool(int fd, const char *group, const char *key,
 			  uint8_t *value)
 {

--- a/src/storage.h
+++ b/src/storage.h
@@ -58,6 +58,11 @@ int storage_read_key_float(int fd, const char *group, const char *key,
 int storage_write_key_float(int fd, const char *group, const char *key,
 			    float value);
 
+int storage_read_key_double(int fd, const char *group, const char *key,
+			   double *value);
+int storage_write_key_double(int fd, const char *group, const char *key,
+			    double value);
+
 int storage_read_key_bool(int fd, const char *group, const char *key,
 			  uint8_t *value);
 int storage_write_key_bool(int fd, const char *group, const char *key,


### PR DESCRIPTION
Changes:

- Added flow to accept double variable;
- Added option to read double variable from OPC UA Protocol.